### PR TITLE
feat: initial MTU exchange implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ bitflags = "1.0.4"
 uuid = { version = "0.7.2", default-features = false }
 ux = { version = "0.1.3", default-features = false }
 bbqueue = "0.3.2"
-log = { git = "https://github.com/rust-lang-nursery/log.git", rev = "75043f9" }
+log = { git = "https://github.com/rust-lang-nursery/log.git", rev = "75043f9", features = ["release_max_level_warn"] }
 
 [profile.dev]
 opt-level = "s"


### PR DESCRIPTION
Stack now successfully connects using nRF Connect app on iOS!

(23 bytes is the default MTU, so is reasonable constant to hardcode for now)