### PR TITLE
chore: update deps

### DIFF
--- a/rubble-demo/Cargo.toml
+++ b/rubble-demo/Cargo.toml
@@ -13,13 +13,13 @@ publish = false
 [dependencies]
 rubble = { path = "../rubble", default-features = false }
 rubble-nrf52 = { path = "../rubble-nrf52", features = ["52810"] }
-cortex-m = "0.5.8"
-cortex-m-semihosting = "=0.3.2"
-cortex-m-rtfm = "0.4.2"
-cortex-m-rt = "0.6.7"
-nrf52810-hal = { version = "0.8.0", features = ["rt"] }
+cortex-m = "0.6.0"
+cortex-m-semihosting = "0.3.3"
+cortex-m-rtfm = "0.4.3"
+cortex-m-rt = "0.6.8"
+nrf52810-hal = { version = "0.8.1", features = ["rt"] }
 byteorder = { version = "1.3.1", default-features = false }
-panic-semihosting = "0.5.1"
+panic-semihosting = "0.5.2"
 bbqueue = "0.3.2"
 
 [dependencies.log]

--- a/rubble-nrf52/Cargo.toml
+++ b/rubble-nrf52/Cargo.toml
@@ -12,9 +12,9 @@ edition = "2018"
 
 [dependencies]
 rubble = { path = "../rubble", version = "0.0.2", default-features = false }
-nrf52810-hal = { version = "0.8.0", optional = true }
-nrf52832-hal = { version = "0.8.0", optional = true }
-nrf52840-hal = { version = "0.8.0", optional = true }
+nrf52810-hal = { version = "0.8.1", optional = true }
+nrf52832-hal = { version = "0.8.1", optional = true }
+nrf52840-hal = { version = "0.8.1", optional = true }
 
 [features]
 52810 = ["nrf52810-hal"]

--- a/rubble/Cargo.toml
+++ b/rubble/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 byteorder = { version = "1.3.1", default-features = false }
 bitflags = "1.0.4"
-uuid = { version = "0.7.2", default-features = false }
+uuid = { version = "0.7.4", default-features = false }
 bbqueue = "0.3.2"
 
 # If the `log` feature is enabled, the `log` crate's macros will be called at various points to dump


### PR DESCRIPTION
Update all the dependencies. This means the example now uses cortex-m 0.6.0.