### PR TITLE
Switch to stable Rust on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-rust: beta
+rust: stable
 env:
   global:
     - TARGET_BUILD=thumbv7em-none-eabi


### PR DESCRIPTION
Beta was used on CI due to an ICE (link goes here), this has since been fixed (link to fix), so we can switch back to using stable Rust.