### PR TITLE
Support thumbv6 platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: rust
 rust: stable
-env:
-  global:
-    - TARGET_BUILD=thumbv7em-none-eabi
-    - RUSTFLAGS="--deny warnings"
 
 install:
-  - rustup target add $TARGET_BUILD
+  - rustup target add thumbv7em-none-eabi
+  - rustup target add thumbv6m-none-eabi
   - rustup component add rustfmt
 
 stages:

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-TARGET_BUILD=${TARGET_BUILD:-thumbv7em-none-eabi}
+RUSTFLAGS=${RUSTFLAGS:---deny warnings}
 
 # First, check formatting.
 echo "Checking code formatting..."
@@ -15,20 +15,26 @@ cargo test --all
 # Check that the device crates build with all feature combinations.
 # Only use `cargo check` because the PAC crates are very slow to build.
 (
-    echo "Checking rubble-nrf52..."
+    TARGET=thumbv7em-none-eabi
+    echo "Checking rubble-nrf52 for $TARGET..."
     cd rubble-nrf52
-    cargo check --features="52810"
-    cargo check --features="52832"
-    cargo check --features="52840"
+    cargo check --features="52810" --target "$TARGET"
+    cargo check --features="52832" --target "$TARGET"
+    cargo check --features="52840" --target "$TARGET"
 )
 
 # Check that the demo app builds with all feature combinations.
 # Here we do a proper build to also make sure linking the final binary works.
-for dir in demos/*; do
+for dir in demos/nrf52*; do
     (
-        echo "Checking $dir..."
+        TARGET=thumbv7em-none-eabi
+        echo "Building $dir for $TARGET..."
         cd "$dir"
-        cargo build --target "$TARGET_BUILD" --no-default-features
-        cargo build --target "$TARGET_BUILD"
+        cargo build --target "$TARGET" --no-default-features
+        cargo build --target "$TARGET"
     )
 done
+
+# Check that the core library builds on thumbv6
+echo "Building rubble for thumbv6m-none-eabi..."
+cargo check -p rubble --target thumbv6m-none-eabi

--- a/demos/nrf52810-demo/src/main.rs
+++ b/demos/nrf52810-demo/src/main.rs
@@ -8,7 +8,7 @@ use panic_semihosting as _;
 mod logger;
 
 use {
-    bbqueue::{bbq, BBQueue, Consumer},
+    bbqueue::Consumer,
     byteorder::{ByteOrder, LittleEndian},
     core::fmt::Write,
     cortex_m_semihosting::hprintln,
@@ -27,7 +27,7 @@ use {
         l2cap::{BleChannelMap, L2CAPState},
         link::{
             ad_structure::AdStructure,
-            queue::{BbqConsumer, BbqProducer, PacketQueue},
+            queue::{PacketQueue, SimpleConsumer, SimpleProducer, SimpleQueue},
             AddressKind, DeviceAddress, LinkLayer, Responder, MIN_PDU_BUF,
         },
         security::NoSecurity,
@@ -46,9 +46,9 @@ impl Config for AppConfig {
     type Transmitter = BleRadio;
     type ChannelMapper = BleChannelMap<BatteryServiceAttrs, NoSecurity>;
 
-    type PacketQueue = &'static BBQueue;
-    type PacketProducer = BbqProducer;
-    type PacketConsumer = BbqConsumer;
+    type PacketQueue = SimpleQueue;
+    type PacketProducer = SimpleProducer<'static>;
+    type PacketConsumer = SimpleConsumer<'static>;
 }
 
 /// Whether to broadcast a beacon or to establish a proper connection.
@@ -62,6 +62,8 @@ const APP: () = {
     static mut BLE_TX_BUF: PacketBuffer = [0; MIN_PDU_BUF];
     static mut BLE_RX_BUF: PacketBuffer = [0; MIN_PDU_BUF];
     static mut BLE_LL: LinkLayer<AppConfig> = ();
+    static mut TX_QUEUE: SimpleQueue = SimpleQueue::new();
+    static mut RX_QUEUE: SimpleQueue = SimpleQueue::new();
     static mut BLE_R: Responder<AppConfig> = ();
     static mut RADIO: BleRadio = ();
     static mut BEACON: Beacon = ();
@@ -69,7 +71,7 @@ const APP: () = {
     static mut SERIAL: Uarte<UARTE0> = ();
     static mut LOG_SINK: Consumer = ();
 
-    #[init(resources = [BLE_TX_BUF, BLE_RX_BUF])]
+    #[init(resources = [BLE_TX_BUF, BLE_RX_BUF, TX_QUEUE, RX_QUEUE])]
     fn init() {
         hprintln!("\n<< INIT >>\n").ok();
 
@@ -152,12 +154,8 @@ const APP: () = {
         let log_sink = logger::init(ble_timer.create_stamp_source());
 
         // Create TX/RX queues
-        // FIXME: Because of how bbqueue works, these have to be 2x the max. PDU size. We don't need
-        // contiguous segments though, so we could use a "normal" queue instead.
-        let tx_queue = bbq![MIN_PDU_BUF * 2].unwrap();
-        let rx_queue = bbq![MIN_PDU_BUF * 2].unwrap();
-        let (tx, tx_cons) = PacketQueue::split(&*tx_queue);
-        let (rx_prod, rx) = PacketQueue::split(&*rx_queue);
+        let (tx, tx_cons) = resources.TX_QUEUE.split();
+        let (rx_prod, rx) = resources.RX_QUEUE.split();
 
         // Create the actual BLE stack objects
         let mut ll = LinkLayer::<AppConfig>::new(device_address, ble_timer);

--- a/demos/nrf52810-demo/src/main.rs
+++ b/demos/nrf52810-demo/src/main.rs
@@ -46,7 +46,7 @@ impl Config for AppConfig {
     type Transmitter = BleRadio;
     type ChannelMapper = BleChannelMap<BatteryServiceAttrs, NoSecurity>;
 
-    type PacketQueue = SimpleQueue;
+    type PacketQueue = &'static mut SimpleQueue;
     type PacketProducer = SimpleProducer<'static>;
     type PacketConsumer = SimpleConsumer<'static>;
 }

--- a/rubble/Cargo.toml
+++ b/rubble/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 byteorder = { version = "1.3.1", default-features = false }
 bitflags = "1.0.4"
 uuid = { version = "0.7.4", default-features = false }
+heapless = "0.5.1"
 
 [dependencies.bbqueue]
 git = "https://github.com/jonas-schievink/bbqueue.git"

--- a/rubble/Cargo.toml
+++ b/rubble/Cargo.toml
@@ -16,10 +16,6 @@ bitflags = "1.0.4"
 uuid = { version = "0.7.4", default-features = false }
 heapless = "0.5.1"
 
-[dependencies.bbqueue]
-git = "https://github.com/jonas-schievink/bbqueue.git"
-branch = "rubble"
-
 # If the `log` feature is enabled, the `log` crate's macros will be called at various points to dump
 # packets, state, and events. By default, it is disabled.
 [dependencies.log]

--- a/rubble/src/config.rs
+++ b/rubble/src/config.rs
@@ -1,6 +1,13 @@
 //! Stack configuration trait.
 
-use crate::{l2cap::ChannelMapper, link::Transmitter, time::Timer};
+use crate::{
+    l2cap::ChannelMapper,
+    link::{
+        queue::{self, PacketQueue},
+        Transmitter,
+    },
+    time::Timer,
+};
 
 // TODO: Use associated type defaults in the trait once stable
 
@@ -21,4 +28,11 @@ pub trait Config {
     ///
     /// This type also provides access to the attributes hosted by the ATT server.
     type ChannelMapper: ChannelMapper;
+
+    /// The packet queue to use for exchanging data between the real-time Link-Layer and
+    /// non-realtime parts of the stack.
+    type PacketQueue: PacketQueue<Producer = Self::PacketProducer, Consumer = Self::PacketConsumer>;
+
+    type PacketProducer: queue::Producer;
+    type PacketConsumer: queue::Consumer;
 }

--- a/rubble/src/config.rs
+++ b/rubble/src/config.rs
@@ -31,7 +31,11 @@ pub trait Config {
 
     /// The packet queue to use for exchanging data between the real-time Link-Layer and
     /// non-realtime parts of the stack.
-    type PacketQueue: PacketQueue<Producer = Self::PacketProducer, Consumer = Self::PacketConsumer>;
+    type PacketQueue: PacketQueue<
+        'static,
+        Producer = Self::PacketProducer,
+        Consumer = Self::PacketConsumer,
+    >;
 
     type PacketProducer: queue::Producer;
     type PacketConsumer: queue::Consumer;

--- a/rubble/src/config.rs
+++ b/rubble/src/config.rs
@@ -31,11 +31,7 @@ pub trait Config {
 
     /// The packet queue to use for exchanging data between the real-time Link-Layer and
     /// non-realtime parts of the stack.
-    type PacketQueue: PacketQueue<
-        'static,
-        Producer = Self::PacketProducer,
-        Consumer = Self::PacketConsumer,
-    >;
+    type PacketQueue: PacketQueue<Producer = Self::PacketProducer, Consumer = Self::PacketConsumer>;
 
     type PacketProducer: queue::Producer;
     type PacketConsumer: queue::Consumer;

--- a/rubble/src/error.rs
+++ b/rubble/src/error.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 /// Errors returned by the BLE stack.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     /// Packet specified an invalid length value or was too short.
     ///

--- a/rubble/src/l2cap/mod.rs
+++ b/rubble/src/l2cap/mod.rs
@@ -28,7 +28,7 @@ use {
         link::{
             data::Llid,
             queue::{Consume, Producer},
-            MIN_PAYLOAD_BUF,
+            MIN_DATA_PAYLOAD_BUF,
         },
         security::{NoSecurity, SecurityLevel, SecurityManager},
         utils::HexSlice,
@@ -156,7 +156,7 @@ impl<'a> ChannelData<'a, dyn ProtocolObj + 'a> {
     /// `Protocol` implementor `T`.
     fn new_dyn<T: Protocol + 'a>(response_channel: Channel, protocol: &'a mut T) -> Self {
         assert!(
-            usize::from(T::RSP_PDU_SIZE + Header::SIZE) <= MIN_PAYLOAD_BUF,
+            usize::from(T::RSP_PDU_SIZE + Header::SIZE) <= MIN_DATA_PAYLOAD_BUF,
             "protocol min PDU is smaller than data channel PDU (L2CAP reassembly NYI)"
         );
 
@@ -171,7 +171,7 @@ impl<'a> ChannelData<'a, dyn ProtocolObj + 'a> {
 impl<'a, P: Protocol> ChannelData<'a, P> {
     fn new(response_channel: Channel, protocol: &'a mut P) -> Self {
         assert!(
-            usize::from(P::RSP_PDU_SIZE + Header::SIZE) <= MIN_PAYLOAD_BUF,
+            usize::from(P::RSP_PDU_SIZE + Header::SIZE) <= MIN_DATA_PAYLOAD_BUF,
             "protocol min PDU is smaller than data channel PDU (L2CAP reassembly NYI)"
         );
 

--- a/rubble/src/link/connection.rs
+++ b/rubble/src/link/connection.rs
@@ -53,8 +53,8 @@ pub struct Connection<C: Config> {
     /// Whether we have ever received a data packet in this connection.
     received_packet: bool,
 
-    tx: Consumer,
-    rx: Producer,
+    tx: C::PacketConsumer,
+    rx: C::PacketProducer,
 
     /// LLCP connection update data received in a previous LL Control PDU.
     ///
@@ -79,8 +79,8 @@ impl<C: Config> Connection<C> {
     pub fn create(
         lldata: &ConnectRequestData,
         rx_end: Instant,
-        tx: Consumer,
-        rx: Producer,
+        tx: C::PacketConsumer,
+        rx: C::PacketProducer,
     ) -> (Self, Cmd) {
         assert_eq!(
             lldata.slave_latency(),
@@ -213,7 +213,7 @@ impl<C: Config> Connection<C> {
 
                 let result: Result<(), Error> =
                     self.rx
-                        .produce_sized_with(header.payload_length().into(), |writer| {
+                        .produce_with(header.payload_length().into(), |writer| {
                             writer.write_slice(payload)?;
                             Ok(header.llid())
                         });

--- a/rubble/src/link/connection.rs
+++ b/rubble/src/link/connection.rs
@@ -14,7 +14,7 @@ use {
         phy::DataChannel,
         time::{Duration, Instant, Timer},
         utils::{Hex, HexSlice},
-        BLUETOOTH_VERSION,
+        Error, BLUETOOTH_VERSION,
     },
     core::{marker::PhantomData, num::Wrapping},
 };
@@ -211,7 +211,14 @@ impl<C: Config> Connection<C> {
                 // Try to buffer the packet. If it fails, we don't acknowledge it, so it will be
                 // resent until we have space.
 
-                if self.rx.produce_raw(header, payload).is_ok() {
+                let result: Result<(), Error> =
+                    self.rx
+                        .produce_sized_with(header.payload_length().into(), |writer| {
+                            writer.write_slice(payload)?;
+                            Ok(header.llid())
+                        });
+
+                if result.is_ok() {
                     // Acknowledge the packet
                     self.next_expected_seq_num += SeqNum::ONE;
                 } else {

--- a/rubble/src/link/mod.rs
+++ b/rubble/src/link/mod.rs
@@ -140,7 +140,6 @@ use {
         ad_structure::AdStructure,
         advertising::{Pdu, PduBuf},
         connection::Connection,
-        queue::{Consumer, Producer},
         seq_num::SeqNum,
     },
     crate::{
@@ -216,7 +215,7 @@ enum State<C: Config> {
         // FIXME: spec check; no idea what order or change delay
         channel: AdvertisingChannel,
 
-        data_queues: Option<(Consumer, Producer)>,
+        data_queues: Option<(C::PacketConsumer, C::PacketProducer)>,
     },
 
     /// Connected with another device.
@@ -262,8 +261,8 @@ impl<C: Config> LinkLayer<C> {
         interval: Duration,
         data: &[AdStructure<'_>],
         transmitter: &mut C::Transmitter,
-        tx: Consumer,
-        rx: Producer,
+        tx: C::PacketConsumer,
+        rx: C::PacketProducer,
     ) -> Result<NextUpdate, Error> {
         // TODO tear down existing connection?
 

--- a/rubble/src/link/mod.rs
+++ b/rubble/src/link/mod.rs
@@ -169,6 +169,18 @@ use {
 /// `x^24 + x^10 + x^9 + x^6 + x^4 + x^3 + x + 1`
 pub const CRC_POLY: u32 = 0b00000001_00000000_00000110_01011011;
 
+/// Min. size a data PDU payload buffer must have (assuming only the bare minimum PDU size is
+/// supported).
+///
+/// Data channel PDUs are smaller than advertising channel PDUs, so this value is less than
+/// `MIN_PAYLOAD_BUF`.
+pub const MIN_DATA_PAYLOAD_BUF: usize = 27;
+
+/// Min. size a data PDU buffer must have.
+///
+/// This is `MIN_DATA_PAYLOAD_BUF` plus the size of the data PDU header (2 Bytes).
+pub const MIN_DATA_PDU_BUF: usize = MIN_DATA_PAYLOAD_BUF + 2;
+
 /// Min. size a PDU payload buffer must have (to cover both advertising and data channels).
 ///
 /// The Advertising PDU header has a length field that is limited to 37 octets, while data channel

--- a/rubble/src/link/queue.rs
+++ b/rubble/src/link/queue.rs
@@ -253,7 +253,7 @@ impl<'a> Producer for SimpleProducer<'a> {
         payload_bytes: u8,
         f: &mut dyn FnMut(&mut ByteWriter<'_>) -> Result<Llid, Error>,
     ) -> Result<(), Error> {
-        assert!(usize::from(payload_bytes) < MIN_PAYLOAD_BUF);
+        assert!(usize::from(payload_bytes) <= MIN_PAYLOAD_BUF);
 
         if !self.inner.ready() {
             return Err(Error::Eof);


### PR DESCRIPTION
This PR prepares the core Rubble library to support thumbv6-based MCUs such as the nRF51 series. It does not yet contain a hardware interface for those MCUs (the intention is still to merge https://github.com/jonas-schievink/rubble/pull/59, which *does* contain the rest needed to use nRF51s).

The PR also makes the packet queue pluggable, which fixes #33 and allows even more platforms to be supported, since you can now implement the queue traits for hardware-based queues or other queue implementations that make use of hardware-provided vendor-specific synchronization mechanisms like monitor peripherals.

The default BBQueue-based packet queue is removed and replaced by a very simple and limited one based on [`heapless::spsc::Queue`](https://docs.rs/heapless/0.5.1/heapless/spsc/struct.Queue.html). This is a slight drawback, but it's now possible to implement the queue traits for custom queues, so it is still possible to use bbqueue. Eventually, once bbqueue is more mature and we don't need to use a git-dependency, we can possibly include the relevant impls in Rubble again.

A nice side effect of this change is that it reduces the RAM usage by quite a lot. The queue size is halved and is only as large as one PDU. The fixed memory overhead of the heapless queue (~2 Bytes (?)) is also much lower than the bbqueue overhead (~26 Bytes (?)).

cc @chocol4te, any thoughts on this?