### PR TITLE
[WIP] Make the demo work with all nrf52 chips

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -33,13 +33,15 @@ cargo test --all
     cargo build --target "$TARGET"
 )
 
-for device in 52810 52832 52840; do
-    (
-        TARGET=thumbv7em-none-eabi
-        echo "Building demos/nrf52-beacon for device $device, target $TARGET..."
-        cd "demos/nrf52-beacon"
-        cargo build --target "$TARGET" --features "$device"
-    )
+for demo in demos/nrf52*; do
+    for device in 52810 52832 52840; do
+        (
+            TARGET=thumbv7em-none-eabi
+            echo "Building $demo for device $device, target $TARGET..."
+            cd "$demo"
+            cargo build --target "$TARGET" --features "$device"
+        )
+    done
 done
 
 # Check that the core library builds on thumbv6

--- a/demos/nrf52810-demo/Cargo.toml
+++ b/demos/nrf52810-demo/Cargo.toml
@@ -12,15 +12,18 @@ publish = false
 
 [dependencies]
 rubble = { path = "../../rubble", default-features = false }
-rubble-nrf52 = { path = "../../rubble-nrf52", features = ["52810"] }
+rubble-nrf52 = { path = "../../rubble-nrf52" }
 demo-utils = { path = "../demo-utils" }
 cortex-m = "0.6.0"
 cortex-m-semihosting = "0.3.3"
 cortex-m-rtfm = "0.4.3"
 cortex-m-rt = "0.6.8"
-nrf52810-hal = { version = "0.8.1", features = ["rt"] }
 byteorder = { version = "1.3.1", default-features = false }
 panic-semihosting = "0.5.2"
+
+nrf52810-hal = { version = "0.8.1", features = ["rt"], optional = true }
+nrf52832-hal = { version = "0.8.1", features = ["rt"], optional = true }
+nrf52840-hal = { version = "0.8.1", features = ["rt"], optional = true }
 
 [dependencies.bbqueue]
 git = "https://github.com/jonas-schievink/bbqueue.git"
@@ -31,13 +34,16 @@ version = "0.4.6"
 features = ["release_max_level_warn"]
 optional = true
 
-[features]
-# Note: To turn this default feature off you must run Cargo from inside the `rubble-demo` directory,
-# not from the workspace root.
-default = ["rubble/log", "log"]
-
 # Disable documentation to avoid spurious rustdoc warnings
 [[bin]]
 name = "nrf52810-demo"
 doc = false
 test = false
+
+[features]
+# Note: To turn this default feature off you must run Cargo from inside the demo
+# directory, not from the workspace root.
+default = ["rubble/log", "log"]
+52810 = ["rubble-nrf52/52810", "nrf52810-hal"]
+52832 = ["rubble-nrf52/52832", "nrf52832-hal"]
+52840 = ["rubble-nrf52/52840", "nrf52840-hal"]

--- a/demos/nrf52810-demo/src/logger.rs
+++ b/demos/nrf52810-demo/src/logger.rs
@@ -1,10 +1,10 @@
 #![cfg_attr(not(feature = "log"), allow(unused))]
 
 use {
+    crate::pac,
     bbqueue::{bbq, BBQueue, Consumer},
     cortex_m::interrupt,
     demo_utils::logging::{BbqLogger, StampedLogger, WriteLogger},
-    nrf52810_hal::nrf52810_pac as pac,
     rubble_nrf52::timer::StampSource,
 };
 

--- a/demos/nrf52810-demo/src/main.rs
+++ b/demos/nrf52810-demo/src/main.rs
@@ -7,18 +7,25 @@ use panic_semihosting as _;
 
 mod logger;
 
+// Import the right HAL/PAC crate, depending on the target chip
+#[cfg(feature = "52810")]
+use nrf52810_hal::{self as hal, nrf52810_pac as pac};
+#[cfg(feature = "52832")]
+use nrf52832_hal::{self as hal, nrf52832_pac as pac};
+#[cfg(feature = "52840")]
+use nrf52840_hal::{self as hal, nrf52840_pac as pac};
+
 use {
     bbqueue::Consumer,
     byteorder::{ByteOrder, LittleEndian},
     core::fmt::Write,
     cortex_m_semihosting::hprintln,
-    nrf52810_hal::{
-        self as hal,
+    hal::{
         gpio::Level,
-        nrf52810_pac::{self as pac, UARTE0},
         prelude::*,
         uarte::{Baudrate, Parity, Uarte},
     },
+    pac::UARTE0,
     rtfm::app,
     rubble::{
         beacon::Beacon,
@@ -57,7 +64,7 @@ impl Config for AppConfig {
 /// at the same time unless you also generate separate device addresses.
 const TEST_BEACON: bool = false;
 
-#[app(device = nrf52810_hal::nrf52810_pac)]
+#[app(device = crate::pac)]
 const APP: () = {
     static mut BLE_TX_BUF: PacketBuffer = [0; MIN_PDU_BUF];
     static mut BLE_RX_BUF: PacketBuffer = [0; MIN_PDU_BUF];


### PR DESCRIPTION
For some reason this breaks running `cargo test` in the workspace root. It runs the build script of the `rubble-nrf52` crate with no features enabled. This fails correctly, but it didn't fail before, which is very weird (the build log still showed `Compiling rubble-nrf52`).

The weird thing is that the `nrf52-beacon` demo *already* works like this without causing this.

Maybe I made a silly mistake somewhere, but this does look like an odd Cargo bug... Investigate!