### PR TITLE
Make the stack (optionally) fully interrupt-driven

### DIFF
--- a/rubble-nrf52/src/radio.rs
+++ b/rubble-nrf52/src/radio.rs
@@ -58,9 +58,7 @@ use {
     pac::{radio::state::STATER, RADIO},
     rubble::{
         config::Config,
-        link::{
-            advertising, data, LinkLayer, NextUpdate, RadioCmd, Transmitter, CRC_POLY, MIN_PDU_BUF,
-        },
+        link::{advertising, data, Cmd, LinkLayer, RadioCmd, Transmitter, CRC_POLY, MIN_PDU_BUF},
         phy::{AdvertisingChannel, DataChannel},
         time::{Duration, Instant},
     },
@@ -261,9 +259,9 @@ impl BleRadio {
         &mut self,
         timestamp: Instant,
         ll: &mut LinkLayer<C>,
-    ) -> NextUpdate {
+    ) -> Option<Cmd> {
         if self.radio.events_disabled.read().bits() == 0 {
-            return NextUpdate::Keep;
+            return None;
         }
 
         // "Subsequent reads and writes cannot be moved ahead of preceding reads."
@@ -302,8 +300,7 @@ impl BleRadio {
             cmd
         };
 
-        self.configure_receiver(cmd.radio);
-        cmd.next_update
+        Some(cmd)
     }
 
     /// Perform preparations to receive or send on an advertising channel.

--- a/rubble/src/beacon.rs
+++ b/rubble/src/beacon.rs
@@ -116,6 +116,8 @@ impl<C: ScanCallback, F: AddressFilter> BeaconScanner<C, F> {
             radio: RadioCmd::ListenAdvertising {
                 channel: self.channel,
             },
+
+            queued_work: false,
         }
     }
 
@@ -132,6 +134,8 @@ impl<C: ScanCallback, F: AddressFilter> BeaconScanner<C, F> {
             radio: RadioCmd::ListenAdvertising {
                 channel: self.channel,
             },
+
+            queued_work: false,
         }
     }
 
@@ -155,6 +159,7 @@ impl<C: ScanCallback, F: AddressFilter> BeaconScanner<C, F> {
             radio: RadioCmd::ListenAdvertising {
                 channel: self.channel,
             },
+            queued_work: false,
         }
     }
 }


### PR DESCRIPTION
Currently, the real-time part of the stack is already purely interrupt-driven (by a timer and a radio interrupt), but the non-real-time part has so far just been an idle loop and there was no way to know whether that processing is necessary before doing it (there was a function to query whether there's data to be processed, but that alone does not allow avoiding the work or moving the work out of the idle loop).

This PR adds feedback from the real-time Link-Layer about whether new low-priority work has been enqueued. This allows an app to only start processing packets via `Responder::process_one` when necessary, which allows to raise the priority of said processing and also enables energy saving by not spinning endlessly waiting for new work to arrive.

~~This PR does not currently work because it contains bugs.~~ Bugs have been fixed.