### PR TITLE
Do not panic when logging buffer is full

### DIFF
--- a/ci/upload-docs.sh
+++ b/ci/upload-docs.sh
@@ -5,7 +5,7 @@ set -o errexit
 echo "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST"
 echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
 
-if [ "$TRAVIS_PULL_REQUEST" == "true" ]; then
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
     exit
 fi
 


### PR DESCRIPTION
Addressing #69

This solution removes the panic when there is not enough capacity and discards the data. It flags the data loss internally, then the next time there is enough buffer capacity it sends a message to inform that there was a loss plus the logged message and resets the flag.