### PR TITLE
Remove logging max_level from demo-utils

### DIFF
--- a/demos/demo-utils/Cargo.toml
+++ b/demos/demo-utils/Cargo.toml
@@ -20,4 +20,3 @@ branch = "rubble"
 
 [dependencies.log]
 version = "0.4.6"
-features = ["release_max_level_warn"]


### PR DESCRIPTION
According to `log` docs:
>Libraries should avoid using the max level features because they're global and can't be changed once they're set.

Also, see: https://github.com/rust-lang/log/issues/309

With this feature enabled here we can't pick the `max_level` on the demos. So currently, this line: https://github.com/jonas-schievink/rubble/blob/f8ff06cbc3de7c14636b7153bc140dad454a4505/demos/nrf52-demo/Cargo.toml#L34 or any modification has no effect.