### PR TITLE
Updated nRF51 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = [
     "rubble",
-    "rubble-nrf52",
+    "rubble-nrf5x",
     "rubble-docs",
     "demos/*/",
 ]

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -12,12 +12,17 @@ cargo test -p rubble
 # Check that the device crates build with all feature combinations.
 # Only use `cargo check` because the PAC crates are very slow to build.
 (
+    cd rubble-nrf5x
+
     TARGET=thumbv7em-none-eabi
-    echo "Checking rubble-nrf52 for $TARGET..."
-    cd rubble-nrf52
+    echo "Checking rubble-nrf5x for $TARGET..."
     cargo check --features="52810" --target "$TARGET"
     cargo check --features="52832" --target "$TARGET"
     cargo check --features="52840" --target "$TARGET"
+
+    TARGET=thumbv6m-none-eabi
+    echo "Checking rubble-nrf5x for $TARGET..."
+    cargo check --features="51" --target "$TARGET"
 )
 
 # Check that the demo apps build with all supported feature combinations.
@@ -34,10 +39,6 @@ for demo in demos/nrf52*; do
     done
 done
 
-# Check that the core library builds on thumbv6
-echo "Building rubble for thumbv6m-none-eabi..."
-cargo check -p rubble --target thumbv6m-none-eabi
-
 # Lastly, check formatting. We'd like to do this earlier, but some crates copy
 # module files around in their build scripts, so they can only be formatted once
 # they've been built at least once.
@@ -48,5 +49,5 @@ cargo fmt --all -- --check
 (
     echo "Generating documentation..."
     cd rubble-docs
-    cargo doc --no-deps -p rubble -p rubble-nrf52
+    cargo doc --no-deps -p rubble -p rubble-nrf5x
 )

--- a/demos/nrf52-beacon/Cargo.toml
+++ b/demos/nrf52-beacon/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 
 [dependencies]
 rubble = { path = "../../rubble", default-features = false }
-rubble-nrf52 = { path = "../../rubble-nrf52" }
+rubble-nrf5x = { path = "../../rubble-nrf5x" }
 demo-utils = { path = "../demo-utils" }
 cortex-m = "0.6.0"
 cortex-m-rtfm = "0.5.0"
@@ -31,6 +31,6 @@ doc = false
 test = false
 
 [features]
-52810 = ["rubble-nrf52/52810", "nrf52810-hal"]
-52832 = ["rubble-nrf52/52832", "nrf52832-hal"]
-52840 = ["rubble-nrf52/52840", "nrf52840-hal"]
+52810 = ["rubble-nrf5x/52810", "nrf52810-hal"]
+52832 = ["rubble-nrf5x/52832", "nrf52832-hal"]
+52840 = ["rubble-nrf5x/52840", "nrf52840-hal"]

--- a/demos/nrf52-beacon/src/main.rs
+++ b/demos/nrf52-beacon/src/main.rs
@@ -21,7 +21,7 @@ use {
         beacon::Beacon,
         link::{ad_structure::AdStructure, AddressKind, DeviceAddress, MIN_PDU_BUF},
     },
-    rubble_nrf52::radio::{BleRadio, PacketBuffer},
+    rubble_nrf5x::radio::{BleRadio, PacketBuffer},
 };
 
 #[rtfm::app(device = crate::hal::target, peripherals = true)]

--- a/demos/nrf52-beacon/src/main.rs
+++ b/demos/nrf52-beacon/src/main.rs
@@ -97,6 +97,7 @@ const APP: () = {
         // beacon.
         let radio = BleRadio::new(
             ctx.device.RADIO,
+            &ctx.device.FICR,
             ctx.resources.ble_tx_buf,
             ctx.resources.ble_rx_buf,
         );

--- a/demos/nrf52-demo/Cargo.toml
+++ b/demos/nrf52-demo/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 
 [dependencies]
 rubble = { path = "../../rubble", default-features = false }
-rubble-nrf52 = { path = "../../rubble-nrf52" }
+rubble-nrf5x = { path = "../../rubble-nrf5x" }
 demo-utils = { path = "../demo-utils" }
 cortex-m = "0.6.0"
 cortex-m-semihosting = "0.3.3"
@@ -44,6 +44,6 @@ test = false
 # Note: To turn this default feature off you must run Cargo from inside the demo
 # directory, not from the workspace root.
 default = ["rubble/log", "log"]
-52810 = ["rubble-nrf52/52810", "nrf52810-hal"]
-52832 = ["rubble-nrf52/52832", "nrf52832-hal"]
-52840 = ["rubble-nrf52/52840", "nrf52840-hal"]
+52810 = ["rubble-nrf5x/52810", "nrf52810-hal"]
+52832 = ["rubble-nrf5x/52832", "nrf52832-hal"]
+52840 = ["rubble-nrf5x/52840", "nrf52840-hal"]

--- a/demos/nrf52-demo/src/logger.rs
+++ b/demos/nrf52-demo/src/logger.rs
@@ -4,7 +4,7 @@ use {
     bbqueue::{bbq, BBQueue, Consumer},
     cortex_m::interrupt,
     demo_utils::logging::{BbqLogger, StampedLogger, WriteLogger},
-    rubble_nrf52::timer::StampSource,
+    rubble_nrf5x::timer::StampSource,
 };
 
 #[cfg(feature = "log")]

--- a/demos/nrf52-demo/src/main.rs
+++ b/demos/nrf52-demo/src/main.rs
@@ -67,7 +67,7 @@ use {
         security::NoSecurity,
         time::{Duration, Timer},
     },
-    rubble_nrf52::{
+    rubble_nrf5x::{
         radio::{BleRadio, PacketBuffer},
         timer::BleTimer,
     },

--- a/demos/nrf52-demo/src/main.rs
+++ b/demos/nrf52-demo/src/main.rs
@@ -145,6 +145,7 @@ const APP: () = {
         let device_address = DeviceAddress::new(devaddr, devaddr_type);
         let mut radio = BleRadio::new(
             ctx.device.RADIO,
+            &ctx.device.FICR,
             ctx.resources.ble_tx_buf,
             ctx.resources.ble_rx_buf,
         );

--- a/rubble-docs/Cargo.toml
+++ b/rubble-docs/Cargo.toml
@@ -7,4 +7,4 @@ version = "0.0.0"
 
 [dependencies]
 rubble = { path = "../rubble" }
-rubble-nrf52 = { path = "../rubble-nrf52", features = ["52840"] }
+rubble-nrf5x = { path = "../rubble-nrf5x", features = ["52840"] }

--- a/rubble-nrf5x/Cargo.toml
+++ b/rubble-nrf5x/Cargo.toml
@@ -1,21 +1,23 @@
 [package]
 authors = ["Jonas Schievink <jonasschievink@gmail.com>"]
-description = "Rubble driver for the nRF52-series radios"
+description = "Rubble driver for the nRF51/nRF52-series radios"
 categories = ["embedded", "no-std"]
 keywords = ["ble", "nrf", "bluetooth", "low", "energy"]
 repository = "https://github.com/jonas-schievink/rubble/"
 license = "0BSD"
-name = "rubble-nrf52"
+name = "rubble-nrf5x"
 version = "0.0.3"
 edition = "2018"
 
 [dependencies]
 rubble = { path = "../rubble", version = "0.0.3", default-features = false }
+nrf51-hal = { version = "0.6.0", optional = true }
 nrf52810-hal = { version = "0.8.1", optional = true }
 nrf52832-hal = { version = "0.8.1", optional = true }
 nrf52840-hal = { version = "0.8.1", optional = true }
 
 [features]
+51 = ["nrf51-hal"]
 52810 = ["nrf52810-hal"]
 52832 = ["nrf52832-hal"]
 52840 = ["nrf52840-hal"]

--- a/rubble-nrf5x/build.rs
+++ b/rubble-nrf5x/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 fn main() {
-    let features = &["52810", "52832", "52840"];
+    let features = &["51", "52810", "52832", "52840"];
     let count = features
         .iter()
         .filter(|name| env::var_os(format!("CARGO_FEATURE_{}", name)).is_some())

--- a/rubble-nrf5x/src/lib.rs
+++ b/rubble-nrf5x/src/lib.rs
@@ -1,4 +1,4 @@
-//! A Rubble BLE driver for the nRF52-series radios.
+//! A Rubble BLE driver for the nRF51/nRF52-series radios.
 
 #![no_std]
 #![warn(rust_2018_idioms)]

--- a/rubble-nrf5x/src/radio.rs
+++ b/rubble-nrf5x/src/radio.rs
@@ -89,7 +89,7 @@ impl BleRadio {
     // TODO: Use type-safe clock configuration to ensure that chip uses ext. crystal
     pub fn new(
         radio: RADIO,
-        #[cfg(feature = "51")] ficr: pac::FICR,
+        ficr: &pac::FICR,
         tx_buf: &'static mut PacketBuffer,
         rx_buf: &'static mut PacketBuffer,
     ) -> Self {

--- a/rubble-nrf5x/src/timer.rs
+++ b/rubble-nrf5x/src/timer.rs
@@ -1,5 +1,8 @@
 //! Generic `Timer` implementation that works with all 3 timers on the chip.
 
+#[cfg(feature = "51")]
+use nrf51_hal::nrf51 as pac;
+
 #[cfg(feature = "52810")]
 use nrf52810_hal::nrf52810_pac as pac;
 
@@ -19,6 +22,8 @@ use {
 };
 
 /// Implements Rubble's `Timer` trait for the timers on the nRF chip.
+///
+/// (note: on the nRF51, only `TIMER0` is usable)
 pub struct BleTimer<T: NrfTimerExt> {
     inner: T,
     next: Instant,
@@ -183,5 +188,8 @@ macro_rules! impl_timer {
 }
 
 impl_timer!(TIMER0);
+
+#[cfg(not(feature = "51"))]
 impl_timer!(TIMER1);
+#[cfg(not(feature = "51"))]
 impl_timer!(TIMER2);


### PR DESCRIPTION
This is an updated version of #59 against the lastest master, and with the code refactored into a single crate, since it turns out there are very few differences between the implementations!

To end up with clear naming without breaking backwards compatibility, I renamed `rubble-nrf52` to `rubble-nrf5x`, and made `rubble-nrf52` a shim crate that re-exports all of rubble-nrf5x - I'm happy to rethink this approach if you would prefer something else.

The nrf51 build is tested in CI, though I have not added demos yet (the `nrf51` crate doesn't provide a `memory.x` (I'm planning to change this)).

I've got the beacon example is working, though I am yet to try the other one (I don't have a pin for UART exposed on the device I'm testing on...). 

![Screenshot_20191129-025638](https://user-images.githubusercontent.com/691552/69811917-03e34400-1254-11ea-9c8b-e446b519458d.jpg)