### PR TITLE
Update dependencies

### DIFF
--- a/demos/demo-utils/Cargo.toml
+++ b/demos/demo-utils/Cargo.toml
@@ -14,7 +14,4 @@ publish = false
 rubble = { path = "../../rubble", default-features = false }
 cortex-m = "0.6.1"
 log = "0.4.8"
-
-[dependencies.bbqueue]
-git = "https://github.com/jonas-schievink/bbqueue.git"
-branch = "rubble"
+bbqueue = "0.4.1"

--- a/demos/demo-utils/Cargo.toml
+++ b/demos/demo-utils/Cargo.toml
@@ -12,11 +12,9 @@ publish = false
 
 [dependencies]
 rubble = { path = "../../rubble", default-features = false }
-cortex-m = "0.6.0"
+cortex-m = "0.6.1"
+log = "0.4.8"
 
 [dependencies.bbqueue]
 git = "https://github.com/jonas-schievink/bbqueue.git"
 branch = "rubble"
-
-[dependencies.log]
-version = "0.4.6"

--- a/demos/nrf52-beacon/Cargo.toml
+++ b/demos/nrf52-beacon/Cargo.toml
@@ -14,10 +14,10 @@ publish = false
 rubble = { path = "../../rubble", default-features = false }
 rubble-nrf5x = { path = "../../rubble-nrf5x" }
 demo-utils = { path = "../demo-utils" }
-cortex-m = "0.6.0"
-cortex-m-rtfm = "0.5.0"
-cortex-m-rt = "0.6.8"
-byteorder = { version = "1.3.1", default-features = false }
+cortex-m = "0.6.1"
+cortex-m-rtfm = "0.5.1"
+cortex-m-rt = "0.6.11"
+byteorder = { version = "1.3.2", default-features = false }
 panic-halt = "0.2.0"
 
 nrf52810-hal = { version = "0.8.1", features = ["rt"], optional = true }

--- a/demos/nrf52-demo/Cargo.toml
+++ b/demos/nrf52-demo/Cargo.toml
@@ -14,12 +14,12 @@ publish = false
 rubble = { path = "../../rubble", default-features = false }
 rubble-nrf5x = { path = "../../rubble-nrf5x" }
 demo-utils = { path = "../demo-utils" }
-cortex-m = "0.6.0"
-cortex-m-semihosting = "0.3.3"
-cortex-m-rtfm = "0.5.0"
-cortex-m-rt = "0.6.8"
-byteorder = { version = "1.3.1", default-features = false }
-panic-semihosting = "0.5.2"
+cortex-m = "0.6.1"
+cortex-m-semihosting = "0.3.5"
+cortex-m-rtfm = "0.5.1"
+cortex-m-rt = "0.6.11"
+byteorder = { version = "1.3.2", default-features = false }
+panic-semihosting = "0.5.3"
 
 nrf52810-hal = { version = "0.8.1", features = ["rt"], optional = true }
 nrf52832-hal = { version = "0.8.1", features = ["rt"], optional = true }
@@ -30,7 +30,7 @@ git = "https://github.com/jonas-schievink/bbqueue.git"
 branch = "rubble"
 
 [dependencies.log]
-version = "0.4.6"
+version = "0.4.8"
 features = ["release_max_level_warn"]
 optional = true
 

--- a/demos/nrf52-demo/Cargo.toml
+++ b/demos/nrf52-demo/Cargo.toml
@@ -20,14 +20,11 @@ cortex-m-rtfm = "0.5.1"
 cortex-m-rt = "0.6.11"
 byteorder = { version = "1.3.2", default-features = false }
 panic-semihosting = "0.5.3"
+bbqueue = "0.4.1"
 
 nrf52810-hal = { version = "0.8.1", features = ["rt"], optional = true }
 nrf52832-hal = { version = "0.8.1", features = ["rt"], optional = true }
 nrf52840-hal = { version = "0.8.1", features = ["rt"], optional = true }
-
-[dependencies.bbqueue]
-git = "https://github.com/jonas-schievink/bbqueue.git"
-branch = "rubble"
 
 [dependencies.log]
 version = "0.4.8"

--- a/demos/nrf52-demo/src/main.rs
+++ b/demos/nrf52-demo/src/main.rs
@@ -100,7 +100,7 @@ const APP: () = {
         ble_r: Responder<AppConfig>,
         radio: BleRadio,
         serial: Uarte<UARTE0>,
-        log_sink: Consumer,
+        log_sink: Consumer<'static, logger::BufferSize>,
     }
 
     #[init(resources = [ble_tx_buf, ble_rx_buf, tx_queue, rx_queue])]
@@ -239,7 +239,8 @@ const APP: () = {
                         ctx.resources.serial.write(chunk).unwrap();
                     }
 
-                    ctx.resources.log_sink.release(grant.buf().len(), grant);
+                    let len = grant.buf().len();
+                    grant.release(len);
                 }
             }
         }

--- a/rubble/Cargo.toml
+++ b/rubble/Cargo.toml
@@ -11,13 +11,13 @@ version = "0.0.3"
 edition = "2018"
 
 [dependencies]
-byteorder = { version = "1.3.1", default-features = false }
+byteorder = { version = "1.3.2", default-features = false }
 bitflags = "1.2.1"
-uuid = { version = "0.8.0", default-features = false }
+uuid = { version = "0.8.1", default-features = false }
 heapless = "0.5.1"
 
 # If the `log` feature is enabled, the `log` crate's macros will be called at various points to dump
 # packets, state, and events. By default, it is disabled.
 [dependencies.log]
-version = "0.4.6"
+version = "0.4.8"
 optional = true


### PR DESCRIPTION
Updates dependencies project-wide, the only non patch bump is a minor bump in nrf51-hal. Does the bbqueue [v0.4.0](https://github.com/jamesmunns/bbqueue/pull/37) release mean we can move away from a git dependency for it? [James said thumbv6 support was implemented](https://github.com/jamesmunns/bbqueue/pull/27#issuecomment-561657682), but I've forgotten if there was something else that was blocking.