### PR TITLE
rubble-nrf5x: Add utils::get_device_address

### DIFF
--- a/demos/nrf52-beacon/Cargo.toml
+++ b/demos/nrf52-beacon/Cargo.toml
@@ -17,7 +17,6 @@ demo-utils = { path = "../demo-utils" }
 cortex-m = "0.6.1"
 cortex-m-rtfm = "0.5.1"
 cortex-m-rt = "0.6.11"
-byteorder = { version = "1.3.2", default-features = false }
 panic-halt = "0.2.0"
 
 nrf52810-hal = { version = "0.10", features = ["rt"], optional = true }

--- a/demos/nrf52-demo/Cargo.toml
+++ b/demos/nrf52-demo/Cargo.toml
@@ -17,7 +17,6 @@ demo-utils = { path = "../demo-utils" }
 cortex-m = "0.6.1"
 cortex-m-rtfm = "0.5.1"
 cortex-m-rt = "0.6.11"
-byteorder = { version = "1.3.2", default-features = false }
 panic-semihosting = "0.5.3"
 bbqueue = "0.4.1"
 

--- a/rubble-nrf5x/Cargo.toml
+++ b/rubble-nrf5x/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.0.3"
 edition = "2018"
 
 [dependencies]
+byteorder = { version = "1.3.2", default-features = false }
 rubble = { path = "../rubble", version = "0.0.3", default-features = false }
 nrf51-hal = { version = "0.10", optional = true, default-features = false }
 nrf52810-hal = { version = "0.10", optional = true, default-features = false }

--- a/rubble-nrf5x/src/lib.rs
+++ b/rubble-nrf5x/src/lib.rs
@@ -5,3 +5,4 @@
 
 pub mod radio;
 pub mod timer;
+pub mod utils;

--- a/rubble-nrf5x/src/utils.rs
+++ b/rubble-nrf5x/src/utils.rs
@@ -1,0 +1,40 @@
+//! Useful utilities related to Rubble on the nRF52.
+
+use byteorder::{ByteOrder, LittleEndian};
+
+#[cfg(feature = "51")]
+use nrf51_hal::pac;
+
+#[cfg(feature = "52810")]
+use nrf52810_hal::pac;
+
+#[cfg(feature = "52832")]
+use nrf52832_hal::pac;
+
+#[cfg(feature = "52840")]
+use nrf52840_hal::pac;
+
+use pac::ficr::deviceaddrtype::DEVICEADDRTYPE_A;
+use rubble::link::{AddressKind, DeviceAddress};
+
+/// Return the `DeviceAddress`, which is pre-programmed in the device FICR
+/// (Factory information configuration registers).
+pub fn get_device_address() -> DeviceAddress {
+    // FICR is read-only, so accessing it directly should be safe
+    let ficr = unsafe { &*pac::FICR::ptr() };
+
+    // Address bytes
+    let mut devaddr = [0u8; 6];
+    let devaddr_lo = ficr.deviceaddr[0].read().bits();
+    let devaddr_hi = ficr.deviceaddr[1].read().bits() as u16;
+    LittleEndian::write_u32(&mut devaddr[..4], devaddr_lo);
+    LittleEndian::write_u16(&mut devaddr[4..], devaddr_hi);
+
+    // Address type
+    let devaddr_type = match ficr.deviceaddrtype.read().deviceaddrtype().variant() {
+        DEVICEADDRTYPE_A::PUBLIC => AddressKind::Public,
+        DEVICEADDRTYPE_A::RANDOM => AddressKind::Random,
+    };
+
+    DeviceAddress::new(devaddr, devaddr_type)
+}


### PR DESCRIPTION
This puts device address extraction code that most dependent crates will use into a utility function.

Instead of putting it in a `utils` module, we could also put it in a `address` module if you'd prefer that.

Note: The `rubble-nrf5x` adds a new dependency on `byteorder`, but that dependency was already there indirectly through `rubble`.