### PR TITLE
Fix string representation of DeviceAddress

### DIFF
--- a/rubble/src/link/device_address.rs
+++ b/rubble/src/link/device_address.rs
@@ -42,6 +42,13 @@ impl DeviceAddress {
 
 impl fmt::Debug for DeviceAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}[{:?}]", self, self.kind)?;
+        Ok(())
+    }
+}
+
+impl fmt::Display for DeviceAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Note: Bluetooth device addresses are usually displayed with MSB
         // first, so that the OUI (Organizationally Unique Identifier) is at
         // the start of the address and thus acts as a prefix, not as a suffix.
@@ -51,9 +58,6 @@ impl fmt::Debug for DeviceAddress {
             }
             write!(f, "{:02x}", b)?;
         }
-
-        write!(f, "[{:?}]", self.kind)?;
-
         Ok(())
     }
 }
@@ -68,5 +72,13 @@ mod tests {
         // https://macaddresschanger.com/bluetooth-mac-lookup/88%3AC6%3A26
         let addr = DeviceAddress::new([0x5A, 0x92, 0x04, 0x26, 0xC6, 0x88], AddressKind::Public);
         assert_eq!(format!("{:?}", addr), "88:c6:26:04:92:5a[Public]");
+    }
+
+    #[test]
+    fn display_representation() {
+        // Logitech device with OUI prefix 88:C6:26
+        // https://macaddresschanger.com/bluetooth-mac-lookup/88%3AC6%3A26
+        let addr = DeviceAddress::new([0x5A, 0x92, 0x04, 0x26, 0xC6, 0x88], AddressKind::Public);
+        assert_eq!(format!("{}", addr), "88:c6:26:04:92:5a");
     }
 }

--- a/rubble/src/link/device_address.rs
+++ b/rubble/src/link/device_address.rs
@@ -42,7 +42,7 @@ impl DeviceAddress {
 
 impl fmt::Debug for DeviceAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}[{:?}]", self, self.kind)?;
+        write!(f, "DeviceAddress({}, {:?})", self, self.kind)?;
         Ok(())
     }
 }
@@ -71,7 +71,10 @@ mod tests {
         // Logitech device with OUI prefix 88:C6:26
         // https://macaddresschanger.com/bluetooth-mac-lookup/88%3AC6%3A26
         let addr = DeviceAddress::new([0x5A, 0x92, 0x04, 0x26, 0xC6, 0x88], AddressKind::Public);
-        assert_eq!(format!("{:?}", addr), "88:c6:26:04:92:5a[Public]");
+        assert_eq!(
+            format!("{:?}", addr),
+            "DeviceAddress(88:c6:26:04:92:5a, Public)"
+        );
     }
 
     #[test]

--- a/rubble/src/link/device_address.rs
+++ b/rubble/src/link/device_address.rs
@@ -19,7 +19,7 @@ pub struct DeviceAddress {
 impl DeviceAddress {
     /// Create a new device address from 6 raw Bytes and an address kind specifier.
     ///
-    /// The `raw` array contains the address Bytes as they are sent over the air (LSB first).
+    /// The `bytes` array contains the address Bytes as they are sent over the air (LSB first).
     pub fn new(bytes: [u8; 6], kind: AddressKind) -> Self {
         DeviceAddress { bytes, kind }
     }
@@ -34,7 +34,7 @@ impl DeviceAddress {
         self.kind == AddressKind::Random
     }
 
-    /// Returns the raw bytes making up this address.
+    /// Returns the raw bytes making up this address (LSB first).
     pub fn raw(&self) -> &[u8; 6] {
         &self.bytes
     }
@@ -42,15 +42,31 @@ impl DeviceAddress {
 
 impl fmt::Debug for DeviceAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for (i, b) in self.bytes.iter().enumerate() {
+        // Note: Bluetooth device addresses are usually displayed with MSB
+        // first, so that the OUI (Organizationally Unique Identifier) is at
+        // the start of the address and thus acts as a prefix, not as a suffix.
+        for (i, b) in self.bytes.iter().rev().enumerate() {
             if i != 0 {
                 f.write_str(":")?;
             }
             write!(f, "{:02x}", b)?;
         }
 
-        write!(f, "({:?})", self.kind)?;
+        write!(f, "[{:?}]", self.kind)?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_representation() {
+        // Logitech device with OUI prefix 88:C6:26
+        // https://macaddresschanger.com/bluetooth-mac-lookup/88%3AC6%3A26
+        let addr = DeviceAddress::new([0x5A, 0x92, 0x04, 0x26, 0xC6, 0x88], AddressKind::Public);
+        assert_eq!(format!("{:?}", addr), "88:c6:26:04:92:5a[Public]");
     }
 }


### PR DESCRIPTION
The address bytes are sent LSB first on the wire, but are usually represented with MSB first.