### PR TITLE
Simplify reference in demos

### DIFF
--- a/demos/nrf52-beacon/src/main.rs
+++ b/demos/nrf52-beacon/src/main.rs
@@ -115,6 +115,6 @@ const APP: () = {
         // Acknowledge event so that the interrupt doesn't keep firing
         ctx.resources.beacon_timer.events_compare[0].reset();
 
-        ctx.resources.beacon.broadcast(&mut *ctx.resources.radio);
+        ctx.resources.beacon.broadcast(ctx.resources.radio);
     }
 };

--- a/demos/nrf52-demo/src/main.rs
+++ b/demos/nrf52-demo/src/main.rs
@@ -208,7 +208,7 @@ const APP: () = {
         }
         timer.clear_interrupt();
 
-        let cmd = ctx.resources.ble_ll.update_timer(&mut *ctx.resources.radio);
+        let cmd = ctx.resources.ble_ll.update_timer(ctx.resources.radio);
         ctx.resources.radio.configure_receiver(cmd.radio);
 
         ctx.resources


### PR DESCRIPTION
RTFM resources are already `&mut` references, so dereferencing and re-referencing them won't help.