### PR TITLE
Passive scanning

### DIFF
--- a/demos/nrf52-demo/src/main.rs
+++ b/demos/nrf52-demo/src/main.rs
@@ -170,7 +170,7 @@ const APP: () = {
         if let Some(cmd) = ctx
             .resources
             .radio
-            .recv_interrupt(ble_ll.timer().now(), ble_ll)
+            .recv_ll_interrupt(ble_ll.timer().now(), ble_ll)
         {
             ctx.resources.radio.configure_receiver(cmd.radio);
             ble_ll.timer().configure_interrupt(cmd.next_update);

--- a/demos/nrf52-scanner/.cargo/config
+++ b/demos/nrf52-scanner/.cargo/config
@@ -1,0 +1,8 @@
+[build]
+target = 'thumbv7em-none-eabi'
+
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+runner = 'arm-none-eabi-gdb'
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]

--- a/demos/nrf52-scanner/Cargo.toml
+++ b/demos/nrf52-scanner/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+authors = ["Danilo Bargen <mail@dbrgn.ch>"]
+description = "Rubble BLE stack demo showcasing passive beacon scanning on the nRF52 MCUs"
+categories = ["embedded", "no-std"]
+keywords = ["arm", "nrf", "bluetooth", "low", "energy"]
+repository = "https://github.com/jonas-schievink/rubble/"
+license = "0BSD"
+name = "nrf52-scanner"
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+rubble = { path = "../../rubble", default-features = false }
+rubble-nrf5x = { path = "../../rubble-nrf5x" }
+demo-utils = { path = "../demo-utils" }
+cortex-m = "0.6.1"
+cortex-m-rtfm = "0.5.1"
+cortex-m-rt = "0.6.11"
+panic-halt = "0.2.0"
+
+nrf52810-hal = { version = "0.10", features = ["rt"], optional = true }
+nrf52832-hal = { version = "0.10", features = ["rt"], optional = true }
+nrf52840-hal = { version = "0.10", features = ["rt"], optional = true }
+
+# Disable documentation to avoid spurious rustdoc warnings
+[[bin]]
+name = "nrf52-scanner"
+doc = false
+test = false
+
+[features]
+52810 = ["rubble-nrf5x/52810", "nrf52810-hal"]
+52832 = ["rubble-nrf5x/52832", "nrf52832-hal"]
+52840 = ["rubble-nrf5x/52840", "nrf52840-hal"]

--- a/demos/nrf52-scanner/README.md
+++ b/demos/nrf52-scanner/README.md
@@ -1,0 +1,10 @@
+# `nrf52-scanner`
+
+A passive beacon scanner.
+
+It does not enable logging and is kept simple and minimal.
+
+The demo works with the nRF52810, nRF52832, and nRF52840. To run it, one of the
+target devices has to be enabled via a Cargo feature:
+
+    cargo run --feature 52810

--- a/demos/nrf52-scanner/src/main.rs
+++ b/demos/nrf52-scanner/src/main.rs
@@ -1,0 +1,116 @@
+#![no_std]
+#![no_main]
+#![warn(rust_2018_idioms)]
+
+// We need to import this crate explicitly so we have a panic handler
+use panic_halt as _;
+
+// Import the right HAL and PAC
+#[cfg(feature = "52810")]
+use nrf52810_hal as hal;
+
+#[cfg(feature = "52832")]
+use nrf52832_hal as hal;
+
+#[cfg(feature = "52840")]
+use nrf52840_hal as hal;
+
+use {
+    rubble::{
+        beacon::{BeaconScanner, ScanCallback},
+        link::{ad_structure::AdStructure, filter::AllowAll, DeviceAddress, MIN_PDU_BUF},
+        time::{Duration, Timer},
+    },
+    rubble_nrf5x::{
+        radio::{BleRadio, PacketBuffer},
+        timer::BleTimer,
+    },
+};
+
+pub struct BeaconScanCallback;
+
+impl ScanCallback for BeaconScanCallback {
+    fn beacon<'a, I>(&mut self, _addr: DeviceAddress, _data: I)
+    where
+        I: Iterator<Item = AdStructure<'a>>,
+    {
+        // Detected an advertisement frame! Do something with it here.
+    }
+}
+
+#[rtfm::app(device = crate::hal::target, peripherals = true)]
+const APP: () = {
+    struct Resources {
+        #[init([0; MIN_PDU_BUF])]
+        ble_tx_buf: PacketBuffer,
+        #[init([0; MIN_PDU_BUF])]
+        ble_rx_buf: PacketBuffer,
+        radio: BleRadio,
+        timer: BleTimer<hal::pac::TIMER0>,
+        scanner: BeaconScanner<BeaconScanCallback, AllowAll>,
+    }
+
+    #[init(resources = [ble_tx_buf, ble_rx_buf])]
+    fn init(ctx: init::Context) -> init::LateResources {
+        // On reset, the internal high frequency clock is already used, but we
+        // also need to switch to the external HF oscillator. This is needed
+        // for Bluetooth to work.
+        let _clocks = hal::clocks::Clocks::new(ctx.device.CLOCK).enable_ext_hfosc();
+
+        // Initialize BLE timer
+        let mut timer = BleTimer::init(ctx.device.TIMER0);
+
+        // Initialize radio
+        let mut radio = BleRadio::new(
+            ctx.device.RADIO,
+            &ctx.device.FICR,
+            ctx.resources.ble_tx_buf,
+            ctx.resources.ble_rx_buf,
+        );
+
+        // Set up beacon scanner for continuous scanning. The advertisement
+        // channel that is being listened on (scan window) will be switched
+        // every 500 ms.
+        let mut scanner = BeaconScanner::new(BeaconScanCallback);
+        let scanner_cmd = scanner.configure(timer.now(), Duration::from_millis(500));
+
+        // Reconfigure radio and timer
+        radio.configure_receiver(scanner_cmd.radio);
+        timer.configure_interrupt(scanner_cmd.next_update);
+
+        init::LateResources {
+            radio,
+            scanner,
+            timer,
+        }
+    }
+
+    #[task(binds = RADIO, resources = [radio, scanner, timer])]
+    fn radio(ctx: radio::Context) {
+        let timer = ctx.resources.timer;
+        let scanner = ctx.resources.scanner;
+        let radio = ctx.resources.radio;
+
+        if let Some(next_update) = radio.recv_beacon_interrupt(scanner) {
+            timer.configure_interrupt(next_update);
+        }
+    }
+
+    #[task(binds = TIMER0, resources = [radio, timer, scanner])]
+    fn timer0(ctx: timer0::Context) {
+        let timer = ctx.resources.timer;
+        let scanner = ctx.resources.scanner;
+        let radio = ctx.resources.radio;
+
+        // Clear interrupt
+        if !timer.is_interrupt_pending() {
+            return;
+        }
+        timer.clear_interrupt();
+
+        // Update scanner (switch to next advertisement channel)
+        let cmd = scanner.timer_update(timer.now());
+        radio.configure_receiver(cmd.radio);
+        timer.configure_interrupt(cmd.next_update);
+    }
+};


### PR DESCRIPTION
The demo currently doesn't do any logging. If we'd simply copy over the logging stuff from `nrf52-demo`, then we'd have a lot of duplication. However, it could be easily added.

Even without logging, the example remains useful.

(I use RTT based logging, so I haven't used UART based logger implementation so far.)