### PR TITLE
Fix rtfm name deprecation warnings in demos

### DIFF
--- a/demos/nrf52-beacon/Cargo.toml
+++ b/demos/nrf52-beacon/Cargo.toml
@@ -15,7 +15,7 @@ rubble = { path = "../../rubble", default-features = false }
 rubble-nrf5x = { path = "../../rubble-nrf5x" }
 demo-utils = { path = "../demo-utils" }
 cortex-m = "0.6.1"
-cortex-m-rtfm = "0.5.1"
+cortex-m-rtic = "0.5.3"
 cortex-m-rt = "0.6.11"
 panic-halt = "0.2.0"
 

--- a/demos/nrf52-beacon/src/main.rs
+++ b/demos/nrf52-beacon/src/main.rs
@@ -20,7 +20,7 @@ use rubble::link::{ad_structure::AdStructure, MIN_PDU_BUF};
 use rubble_nrf5x::radio::{BleRadio, PacketBuffer};
 use rubble_nrf5x::utils::get_device_address;
 
-#[rtfm::app(device = crate::hal::target, peripherals = true)]
+#[rtic::app(device = crate::hal::target, peripherals = true)]
 const APP: () = {
     struct Resources {
         #[init([0; MIN_PDU_BUF])]

--- a/demos/nrf52-demo/Cargo.toml
+++ b/demos/nrf52-demo/Cargo.toml
@@ -15,7 +15,7 @@ rubble = { path = "../../rubble", default-features = false }
 rubble-nrf5x = { path = "../../rubble-nrf5x" }
 demo-utils = { path = "../demo-utils" }
 cortex-m = "0.6.1"
-cortex-m-rtfm = "0.5.1"
+cortex-m-rtic = "0.5.3"
 cortex-m-rt = "0.6.11"
 panic-semihosting = "0.5.3"
 bbqueue = "0.4.1"

--- a/demos/nrf52-demo/src/main.rs
+++ b/demos/nrf52-demo/src/main.rs
@@ -67,7 +67,7 @@ impl Config for AppConfig {
     type PacketQueue = &'static mut SimpleQueue;
 }
 
-#[rtfm::app(device = crate::hal::target, peripherals = true)]
+#[rtic::app(device = crate::hal::target, peripherals = true)]
 const APP: () = {
     struct Resources {
         #[init([0; MIN_PDU_BUF])]


### PR DESCRIPTION
Just accommodating the `rtfm` rename to `rtic` - I don't think this includes any functional change.