### PR TITLE
Remove byteorder dependency

### DIFF
--- a/rubble-nrf5x/Cargo.toml
+++ b/rubble-nrf5x/Cargo.toml
@@ -10,7 +10,6 @@ version = "0.0.3"
 edition = "2018"
 
 [dependencies]
-byteorder = { version = "1.3.2", default-features = false }
 rubble = { path = "../rubble", version = "0.0.3", default-features = false }
 nrf51-hal = { version = "0.10", optional = true, default-features = false }
 nrf52810-hal = { version = "0.10", optional = true, default-features = false }

--- a/rubble-nrf5x/src/utils.rs
+++ b/rubble-nrf5x/src/utils.rs
@@ -1,7 +1,5 @@
 //! Useful utilities related to Rubble on the nRF52.
 
-use byteorder::{ByteOrder, LittleEndian};
-
 #[cfg(feature = "51")]
 use nrf51_hal::pac;
 
@@ -27,8 +25,8 @@ pub fn get_device_address() -> DeviceAddress {
     let mut devaddr = [0u8; 6];
     let devaddr_lo = ficr.deviceaddr[0].read().bits();
     let devaddr_hi = ficr.deviceaddr[1].read().bits() as u16;
-    LittleEndian::write_u32(&mut devaddr[..4], devaddr_lo);
-    LittleEndian::write_u16(&mut devaddr[4..], devaddr_hi);
+    devaddr[..4].copy_from_slice(&devaddr_lo.to_le_bytes());
+    devaddr[4..].copy_from_slice(&devaddr_hi.to_le_bytes());
 
     // Address type
     let devaddr_type = match ficr.deviceaddrtype.read().deviceaddrtype().variant() {

--- a/rubble/Cargo.toml
+++ b/rubble/Cargo.toml
@@ -11,7 +11,6 @@ version = "0.0.3"
 edition = "2018"
 
 [dependencies]
-byteorder = { version = "1.3.2", default-features = false }
 bitflags = "1.2.1"
 uuid = { version = "0.8.1", default-features = false }
 heapless = "0.5.1"

--- a/rubble/src/bytes.rs
+++ b/rubble/src/bytes.rs
@@ -18,7 +18,6 @@
 //! [`BytesOr`]: struct.BytesOr.html
 
 use crate::Error;
-use byteorder::{ByteOrder, LittleEndian};
 use core::{cmp, fmt, iter, mem};
 
 /// Reference to a `T`, or to a byte slice that can be decoded as a `T`.
@@ -354,9 +353,7 @@ impl<'a> ByteWriter<'a> {
     /// If `self` does not have enough space left, an error will be returned and no bytes will be
     /// written to `self`.
     pub fn write_u16_le(&mut self, value: u16) -> Result<(), Error> {
-        let mut bytes = [0; 2];
-        LittleEndian::write_u16(&mut bytes, value);
-        self.write_slice(&bytes)
+        self.write_slice(&value.to_le_bytes())
     }
 
     /// Writes a `u32` to `self`, using Little Endian byte order.
@@ -364,9 +361,7 @@ impl<'a> ByteWriter<'a> {
     /// If `self` does not have enough space left, an error will be returned and no bytes will be
     /// written to `self`.
     pub fn write_u32_le(&mut self, value: u32) -> Result<(), Error> {
-        let mut bytes = [0; 4];
-        LittleEndian::write_u32(&mut bytes, value);
-        self.write_slice(&bytes)
+        self.write_slice(&value.to_le_bytes())
     }
 
     /// Writes a `u64` to `self`, using Little Endian byte order.
@@ -374,9 +369,7 @@ impl<'a> ByteWriter<'a> {
     /// If `self` does not have enough space left, an error will be returned and no bytes will be
     /// written to `self`.
     pub fn write_u64_le(&mut self, value: u64) -> Result<(), Error> {
-        let mut bytes = [0; 8];
-        LittleEndian::write_u64(&mut bytes, value);
-        self.write_slice(&bytes)
+        self.write_slice(&value.to_le_bytes())
     }
 }
 
@@ -495,19 +488,19 @@ impl<'a> ByteReader<'a> {
     /// Reads a `u16` from `self`, using Little Endian byte order.
     pub fn read_u16_le(&mut self) -> Result<u16, Error> {
         let arr = self.read_array::<[u8; 2]>()?;
-        Ok(LittleEndian::read_u16(&arr))
+        Ok(u16::from_le_bytes(arr))
     }
 
     /// Reads a `u32` from `self`, using Little Endian byte order.
     pub fn read_u32_le(&mut self) -> Result<u32, Error> {
         let arr = self.read_array::<[u8; 4]>()?;
-        Ok(LittleEndian::read_u32(&arr))
+        Ok(u32::from_le_bytes(arr))
     }
 
     /// Reads a `u64` from `self`, using Little Endian byte order.
     pub fn read_u64_le(&mut self) -> Result<u64, Error> {
         let arr = self.read_array::<[u8; 8]>()?;
-        Ok(LittleEndian::read_u64(&arr))
+        Ok(u64::from_le_bytes(arr))
     }
 }
 

--- a/rubble/src/link/advertising.rs
+++ b/rubble/src/link/advertising.rs
@@ -11,8 +11,7 @@ use crate::link::ad_structure::{AdStructure, Flags};
 use crate::link::{channel_map::ChannelMap, AddressKind, DeviceAddress};
 use crate::utils::{Hex, HexSlice};
 use crate::{bytes::*, time::Duration, Error};
-use byteorder::{ByteOrder, LittleEndian};
-use core::{fmt, iter};
+use core::{convert::TryInto, fmt, iter};
 
 /// CRC initialization value for advertising channel packets.
 ///
@@ -694,7 +693,8 @@ impl Header {
     }
 
     pub fn parse(raw: &[u8]) -> Self {
-        Header(LittleEndian::read_u16(&raw))
+        let bytes: [u8; 2] = raw[..2].try_into().expect("raw has fewer than 2 bytes");
+        Header(u16::from_le_bytes(bytes))
     }
 
     /// Returns the raw representation of the header.

--- a/rubble/src/link/data.rs
+++ b/rubble/src/link/data.rs
@@ -174,6 +174,19 @@ impl fmt::Debug for Header {
     }
 }
 
+impl<'a> FromBytes<'a> for Header {
+    fn from_bytes(bytes: &mut ByteReader<'a>) -> Result<Self, Error> {
+        let raw = bytes.read_u16_le()?;
+        Ok(Header(raw))
+    }
+}
+
+impl ToBytes for Header {
+    fn to_bytes(&self, writer: &mut ByteWriter<'_>) -> Result<(), Error> {
+        writer.write_u16_le(self.to_u16())
+    }
+}
+
 /// Values of the LLID field in `Header`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Llid {

--- a/rubble/src/link/data.rs
+++ b/rubble/src/link/data.rs
@@ -2,8 +2,7 @@
 
 use crate::link::{llcp::ControlPdu, SeqNum};
 use crate::{bytes::*, Error};
-use byteorder::{ByteOrder, LittleEndian};
-use core::fmt;
+use core::{convert::TryInto, fmt};
 
 /// 16-bit data channel header preceding the payload.
 ///
@@ -74,7 +73,8 @@ impl Header {
     ///
     /// Panics when `raw` contains less than 2 Bytes.
     pub fn parse(raw: &[u8]) -> Self {
-        Header(LittleEndian::read_u16(&raw))
+        let bytes: [u8; 2] = raw[..2].try_into().expect("raw has fewer than 2 bytes");
+        Header(u16::from_le_bytes(bytes))
     }
 
     /// Returns the raw representation of the header.

--- a/rubble/src/link/queue.rs
+++ b/rubble/src/link/queue.rs
@@ -22,7 +22,6 @@
 use crate::link::data::{self, Llid};
 use crate::link::{MIN_DATA_PAYLOAD_BUF, MIN_DATA_PDU_BUF};
 use crate::{bytes::*, Error};
-use byteorder::{ByteOrder, LittleEndian};
 use heapless::consts::U1;
 use heapless::spsc::{self, MultiCore};
 
@@ -258,7 +257,7 @@ impl<'a> Producer for SimpleProducer<'a> {
 
         let mut header = data::Header::new(llid);
         header.set_payload_length(used as u8);
-        LittleEndian::write_u16(&mut buf, header.to_u16());
+        header.to_bytes(&mut ByteWriter::new(&mut buf[..2]))?;
 
         self.inner.enqueue(buf).map_err(|_| ()).unwrap();
         Ok(())

--- a/rubble/src/uuid.rs
+++ b/rubble/src/uuid.rs
@@ -15,7 +15,6 @@
 //! `1234ABCD-0000-1000-8000-00805F9B34FB`.
 
 use crate::{bytes::*, Error};
-use byteorder::{BigEndian, ByteOrder};
 use core::fmt;
 
 pub use uuid::Uuid;
@@ -53,7 +52,7 @@ impl Into<Uuid> for Uuid16 {
 impl Into<Uuid> for Uuid32 {
     fn into(self) -> Uuid {
         let mut buf = BASE_UUID;
-        BigEndian::write_u32(&mut buf, self.0);
+        buf[..4].copy_from_slice(&self.0.to_be_bytes());
         Uuid::from_bytes(buf)
     }
 }


### PR DESCRIPTION
I included a fix for the last remaining header not implementing `FromBytes`/`ToBytes` in this PR, as that made removing `byteorder` easily. This could also be submitted separately, if you want.

I think the majority of places `byteorder` was used were more than well covered by the new `from/to_le/be_bytes` methods on integers. A few places where we're actually using it to read/write to byte slices needed more changes, mainly using `copy_from_slice` or `try_into` to convert `&[u8]` to `[u8; N]`.

Let me know how this looks?

Fixes #24. CC #122.