### PR TITLE
Remove flags, as they are not needed according to Bluetooth 4.2 specification

### DIFF
--- a/rubble/src/link/advertising.rs
+++ b/rubble/src/link/advertising.rs
@@ -575,11 +575,7 @@ impl PduBuf {
         advertiser_addr: DeviceAddress,
         advertiser_data: &[AdStructure<'_>],
     ) -> Result<Self, Error> {
-        Self::adv(
-            PduType::AdvNonconnInd,
-            advertiser_addr,
-            &mut advertiser_data.iter(),
-        )
+        Self::nonconnectable_undirected(advertiser_addr, advertiser_data)
     }
 
     /// Creates an advertising PDU that makes this device "visible" for scanning

--- a/rubble/src/link/advertising.rs
+++ b/rubble/src/link/advertising.rs
@@ -570,9 +570,7 @@ impl PduBuf {
     /// Creates an advertising channel PDU suitable for building a simple
     /// beacon.
     ///
-    /// This is mostly equivalent to `PduBuf::nonconnectable_undirected`, but it
-    /// will automatically add a suitable `Flags` AD structure to the
-    /// advertising data (this flags is mandatory).
+    /// This is equivalent to `PduBuf::nonconnectable_undirected`.
     pub fn beacon(
         advertiser_addr: DeviceAddress,
         advertiser_data: &[AdStructure<'_>],
@@ -580,7 +578,7 @@ impl PduBuf {
         Self::adv(
             PduType::AdvNonconnInd,
             advertiser_addr,
-            &mut iter::once(&AdStructure::from(Flags::broadcast())).chain(advertiser_data),
+            &mut advertiser_data.iter(),
         )
     }
 


### PR DESCRIPTION
Bluetooth specification 4.2:

```
9.2.2.2 Conditions
A device in the non-discoverable mode that sends advertising events shall not
set the ‘LE General Discoverable Mode’ flag or ‘LE Limited Discoverable Mode’
flag in the Flags AD type (see [Core Specification Supplement], Part A, Section
1.3). A Peripheral device in the non-connectable mode may send non-
connectable undirected advertising events or scannable undirected advertising
events or may not send advertising packets.
```

Sounds to me like sending no Flags AD is totally fine and correct (and saves 3 bytes).