### PR TITLE
Create constructor and value-getter for Attribute::value

### DIFF
--- a/rubble/src/att/mod.rs
+++ b/rubble/src/att/mod.rs
@@ -55,6 +55,7 @@ pub struct Attribute<'a> {
 impl<'a> Attribute<'a> {
     /// Creates a new attribute.
     pub fn new(att_type: AttUuid, handle: Handle, value: &'a [u8]) -> Self {
+        assert_ne!(handle, Handle::NULL);
         Attribute {
             att_type,
             handle,

--- a/rubble/src/att/mod.rs
+++ b/rubble/src/att/mod.rs
@@ -52,6 +52,22 @@ pub struct Attribute<'a> {
     pub value: HexSlice<&'a [u8]>,
 }
 
+impl<'a> Attribute<'a> {
+    /// Creates a new attribute.
+    pub fn new(att_type: AttUuid, handle: Handle, value: &'a [u8]) -> Self {
+        Attribute {
+            att_type,
+            handle,
+            value: HexSlice(value),
+        }
+    }
+
+    /// Retrieves the attribute's value as a slice.
+    pub fn value(&self) -> &'a [u8] {
+        self.value.as_ref()
+    }
+}
+
 /// Trait for attribute sets that can be hosted by an `AttributeServer`.
 pub trait AttributeProvider {
     /// Calls a closure `f` with every attribute whose handle is inside `range`, ascending.


### PR DESCRIPTION
Fixes #134! This adds an `Attribute::new` function taking `&[u8]` and `Attribute::value` function returning the value as `&[u8]`.

I've made this as a minimal change - I think it could be reasonable to add getters for the other fields for consistency, and/or make the fields private, but those aren't strictly necessary to fix this issue.

Let me know if there's anything else I can do with this!