### PR TITLE
Add function to `LinkLayer` for entering standby

### DIFF
--- a/rubble/src/link/mod.rs
+++ b/rubble/src/link/mod.rs
@@ -382,6 +382,16 @@ impl<C: Config> LinkLayer<C> {
         }
     }
 
+    /// Updates the Link-Layer to stop advertising and forget connection status.
+    pub fn enter_standby(&mut self) -> Cmd {
+        self.state = State::Standby;
+        Cmd {
+            next_update: NextUpdate::Disable,
+            radio: RadioCmd::Off,
+            queued_work: false,
+        }
+    }
+
     /// Update the Link-Layer state after the timer expires.
     ///
     /// This should be called whenever the timer set by the last returned `Cmd` has expired.


### PR DESCRIPTION
I'm mainly wanting to arbitrarily stop advertising - I'm not at all sure how much this makes sense in practice, but it seems like a useful control to have for completeness? It's a single function `LinkLayer::enter_standby` which returns a `Cmd` and does as the name suggests.

This doesn't gracefully end connections - it's doing the same thing as starting advertising when one has an existing connection, but just not advertising instead.