### PR TITLE
Allow to mutate AttributeProvider

### DIFF
--- a/rubble/src/att/mod.rs
+++ b/rubble/src/att/mod.rs
@@ -67,6 +67,11 @@ impl<'a> Attribute<'a> {
     pub fn value(&self) -> &'a [u8] {
         self.value.as_ref()
     }
+
+    /// Overrides the previously set attribute's value.
+    pub fn set_value(&mut self, value: &'a [u8]) {
+        self.value = HexSlice(value)
+    }
 }
 
 /// Trait for attribute sets that can be hosted by an `AttributeServer`.

--- a/rubble/src/att/server.rs
+++ b/rubble/src/att/server.rs
@@ -32,6 +32,11 @@ impl<A: AttributeProvider> AttributeServer<A> {
         }
     }
 
+    /// Provides mutable access to the underlying `AttributeProvider`.
+    pub fn provider(&mut self) -> &mut A {
+        &mut self.attrs
+    }
+
     /// Returns the `ATT_MTU` value, the maximum size of an ATT PDU that can be processed and sent
     /// out by the server.
     fn att_mtu(&self) -> u8 {

--- a/rubble/src/l2cap/mod.rs
+++ b/rubble/src/l2cap/mod.rs
@@ -244,6 +244,11 @@ impl<A: AttributeProvider> BleChannelMap<A, NoSecurity> {
             sm: SecurityManager::no_security(),
         }
     }
+
+    /// Provides mutable access to the underlying `AttributeProvider`.
+    pub fn attribute_provider(&mut self) -> &mut A {
+        self.att.provider()
+    }
 }
 
 impl<A: AttributeProvider, S: SecurityLevel> ChannelMapper for BleChannelMap<A, S> {
@@ -366,6 +371,11 @@ impl<M: ChannelMapper> L2CAPState<M> {
     /// Gives this instance the ability to transmit packets.
     pub fn tx<'a, P: Producer>(&'a mut self, tx: &'a mut P) -> L2CAPStateTx<'a, M, P> {
         L2CAPStateTx { l2cap: self, tx }
+    }
+
+    /// Provides mutable access to the underlying `ChannelMapper`.
+    pub fn channel_mapper(&mut self) -> &mut M {
+        &mut self.mapper
     }
 }
 


### PR DESCRIPTION
This changeset makes it possible to mutate the AttributeProvider,
making it possible to change attribute values during the
runtime of the application.

This should at least basically cover the needs for #150 