### PR TITLE
reply to LL_VERSION_IND once per connection

### DIFF
--- a/rubble/src/link/connection.rs
+++ b/rubble/src/link/connection.rs
@@ -197,8 +197,11 @@ impl<C: Config> Connection<C> {
                         Err(LlcpError::ConnectionLost) => {
                             return Err(());
                         }
-                        Err(LlcpError::NoSpace) | Err(LlcpError::VersionIndSent) => {
+                        Err(LlcpError::NoSpace) => {
                             // Do not acknowledge the PDU
+                        }
+                        Err(LlcpError::VersionIndSent) => {
+                            error!("Received 'LL_VERSION_IND' (LL Control PDU) more than once");
                         }
                     }
                 } else {
@@ -544,7 +547,7 @@ enum LlcpError {
     /// Consider the connection lost due to a critical error or timeout.
     ConnectionLost,
 
-    /// Shouldn't send Control PDU *LL_VERSION_IND* more than once.
+    /// Already sent Control PDU *LL_VERSION_IND* (indicates invalid behavior by the other device).
     VersionIndSent,
 }
 

--- a/rubble/src/link/connection.rs
+++ b/rubble/src/link/connection.rs
@@ -49,6 +49,9 @@ pub struct Connection<C: Config> {
     tx: ConfConsumer<C>,
     rx: ConfProducer<C>,
 
+    /// Whether we have already sent 'LL_VERSION_IND' (LL Control PDU).
+    sent_version_ind: bool,
+
     /// LLCP connection update data received in a previous LL Control PDU.
     ///
     /// Contains the *instant* at which it should be applied to the Link Layer state.
@@ -93,6 +96,8 @@ impl<C: Config> Connection<C> {
 
             tx,
             rx,
+
+            sent_version_ind: false,
             update_data: None,
 
             _p: PhantomData,
@@ -192,7 +197,7 @@ impl<C: Config> Connection<C> {
                         Err(LlcpError::ConnectionLost) => {
                             return Err(());
                         }
-                        Err(LlcpError::NoSpace) => {
+                        Err(LlcpError::NoSpace) | Err(LlcpError::VersionIndSent) => {
                             // Do not acknowledge the PDU
                         }
                     }
@@ -438,6 +443,12 @@ impl<C: Config> Connection<C> {
                 // FIXME this should correlate with the Cargo package version
                 let sub_vers_nr = 0x0000;
 
+                if self.sent_version_ind {
+                    // Shouldn't send Control PDU *LL_VERSION_IND* more than once.
+                    return Err(LlcpError::VersionIndSent);
+                }
+                self.sent_version_ind = true;
+
                 ControlPdu::VersionInd {
                     vers_nr: BLUETOOTH_VERSION,
                     comp_id: CompanyId::from_raw(comp_id),
@@ -532,6 +543,9 @@ enum LlcpError {
 
     /// Consider the connection lost due to a critical error or timeout.
     ConnectionLost,
+
+    /// Shouldn't send Control PDU *LL_VERSION_IND* more than once.
+    VersionIndSent,
 }
 
 /// A Link-Layer state update that may be applied with a delay.


### PR DESCRIPTION
Hello ! :crab:

This PR is for issue #49 .
(relevant to **Version Exchange procedure** section of bluetooth 5.2 core specs)

I added a `bool` member to `Connection` that keeps track of
whether we had previously sent a Control PDU `LL_VERSION_IND` for the connection.
I also added a new variant `VersionIndSent` to enum `LlcpError`.

It is also mentioned in #49 that eventually we want to collapse all bool state variables to a single byte as bitflags,
but I didn't make that change in this PR. So I guess the issue should be kept open?

Thank you for reviewing this PR ! :+1: 