### PR TITLE
Reexport HexSlice and Error

### DIFF
--- a/rubble/src/att/mod.rs
+++ b/rubble/src/att/mod.rs
@@ -35,7 +35,7 @@ mod server;
 mod uuid;
 
 use self::{handle::*, pdus::*};
-use crate::{utils::HexSlice, Error};
+pub use crate::{utils::HexSlice, Error};
 
 pub use self::handle::{Handle, HandleRange};
 pub use self::server::{AttributeServer, AttributeServerTx};


### PR DESCRIPTION
These types need to be exported for custom AttributeProvider's to be
written outside of rubble.