### PR TITLE
Use a trait for representing attribute values

### DIFF
--- a/rubble/src/att/server.rs
+++ b/rubble/src/att/server.rs
@@ -2,7 +2,7 @@
 
 use super::{
     pdus::{AttPdu, ByGroupAttData, ByTypeAttData, ErrorCode, Opcode},
-    AttError, AttrValue, AttributeProvider, Handle, HandleRange,
+    AttError, AttributeProvider, Handle, HandleRange,
 };
 use crate::bytes::{ByteReader, FromBytes, ToBytes};
 use crate::l2cap::{Protocol, ProtocolObj, Sender};

--- a/rubble/src/att/server.rs
+++ b/rubble/src/att/server.rs
@@ -2,7 +2,7 @@
 
 use super::{
     pdus::{AttPdu, ByGroupAttData, ByTypeAttData, ErrorCode, Opcode},
-    AttError, AttributeProvider, Handle, HandleRange,
+    AttError, AttrValue, AttributeProvider, Handle, HandleRange,
 };
 use crate::bytes::{ByteReader, FromBytes, ToBytes};
 use crate::l2cap::{Protocol, ProtocolObj, Sender};
@@ -99,7 +99,7 @@ impl<A: AttributeProvider> AttributeServer<A> {
                         .for_attrs_in_range(range, |_provider, attr| {
                             if attr.att_type == *attribute_type {
                                 let data =
-                                    ByTypeAttData::new(att_mtu, attr.handle, attr.value.as_ref());
+                                    ByTypeAttData::new(att_mtu, attr.handle, attr.value.as_slice());
                                 if size == Some(data.encoded_size()) || size.is_none() {
                                     // Can try to encode `data`. If we run out of space, end the list.
                                     data.to_bytes(writer)?;
@@ -156,7 +156,7 @@ impl<A: AttributeProvider> AttributeServer<A> {
                                     att_mtu,
                                     attr.handle,
                                     provider.group_end(attr.handle).unwrap().handle,
-                                    attr.value.as_ref(),
+                                    attr.value.as_slice(),
                                 );
                                 if size == Some(data.encoded_size()) || size.is_none() {
                                     // Can try to encode `data`. If we run out of space, end the list.
@@ -197,10 +197,10 @@ impl<A: AttributeProvider> AttributeServer<A> {
                         self.attrs.for_attrs_in_range(
                             HandleRange::new(*handle, *handle),
                             |_provider, attr| {
-                                let value = if writer.space_left() < attr.value.as_ref().len() {
-                                    &attr.value.as_ref()[..writer.space_left()]
+                                let value = if writer.space_left() < attr.value.as_slice().len() {
+                                    &attr.value.as_slice()[..writer.space_left()]
                                 } else {
-                                    attr.value.as_ref()
+                                    attr.value.as_slice()
                                 };
                                 writer.write_slice(value)
                             },

--- a/rubble/src/gatt/mod.rs
+++ b/rubble/src/gatt/mod.rs
@@ -5,7 +5,7 @@
 
 pub mod characteristic;
 
-use crate::att::{AttUuid, Attribute, AttributeProvider, Handle, HandleRange};
+use crate::att::{AttUuid, AttrValue, Attribute, AttributeProvider, Handle, HandleRange};
 use crate::uuid::{Uuid128, Uuid16};
 use crate::Error;
 use core::cmp;
@@ -45,11 +45,10 @@ impl BatteryServiceAttrs {
 }
 
 impl AttributeProvider for BatteryServiceAttrs {
-    type ValueType = &'static [u8];
     fn for_attrs_in_range(
         &mut self,
         range: HandleRange,
-        mut f: impl FnMut(&Self, &Attribute<Self::ValueType>) -> Result<(), Error>,
+        mut f: impl FnMut(&Self, &Attribute<dyn AttrValue>) -> Result<(), Error>,
     ) -> Result<(), Error> {
         let count = self.attributes.len();
         let start = usize::from(range.start().as_u16() - 1); // handles start at 1, not 0
@@ -72,7 +71,7 @@ impl AttributeProvider for BatteryServiceAttrs {
         uuid == Uuid16(0x2800) // FIXME not characteristics?
     }
 
-    fn group_end(&self, handle: Handle) -> Option<&Attribute<Self::ValueType>> {
+    fn group_end(&self, handle: Handle) -> Option<&Attribute<dyn AttrValue>> {
         match handle.as_u16() {
             0x0001 => Some(&self.attributes[2]),
             0x0002 => Some(&self.attributes[2]),
@@ -156,11 +155,10 @@ impl MidiServiceAttrs {
 }
 
 impl AttributeProvider for MidiServiceAttrs {
-    type ValueType = &'static [u8];
     fn for_attrs_in_range(
         &mut self,
         range: HandleRange,
-        mut f: impl FnMut(&Self, &Attribute<Self::ValueType>) -> Result<(), Error>,
+        mut f: impl FnMut(&Self, &Attribute<dyn AttrValue>) -> Result<(), Error>,
     ) -> Result<(), Error> {
         let count = self.attributes.len();
         let start = usize::from(range.start().as_u16() - 1); // handles start at 1, not 0
@@ -183,7 +181,7 @@ impl AttributeProvider for MidiServiceAttrs {
         uuid == Uuid16(0x2800) // FIXME not characteristics?
     }
 
-    fn group_end(&self, handle: Handle) -> Option<&Attribute<Self::ValueType>> {
+    fn group_end(&self, handle: Handle) -> Option<&Attribute<dyn AttrValue>> {
         match handle.as_u16() {
             0x0001 => Some(&self.attributes[3]),
             0x0002 => Some(&self.attributes[3]),


### PR DESCRIPTION
This makes it easier to use attributes in environments where using
static lifetimes for attribute values is challenging by allowing the
attribute service to use its own types that can choose how to store the attribute
values.

In addition, the usage of attribute in the AttributeProvider now takes a
reference to the Attribute instead of a copy to allow the attribute
service more freedom in implementing.

@jonas-schievink Consider this a proposal/draft to provide more flexibility of the attribute API as discussed in #153. I'm still not super-satisfied with this, given that the AttrValue implementation would need to cover all possible values for the different characteristics.