### PR TITLE
Fix clippy warnings

### DIFF
--- a/rubble/src/bytes.rs
+++ b/rubble/src/bytes.rs
@@ -275,7 +275,7 @@ impl<'a> ByteWriter<'a> {
     /// Note that if the created `ByteWriter` is not used, the bytes will contain whatever contents
     /// they had before creating `self` (ie. most likely garbage data left over from earlier use).
     /// If you are really sure you want that, `skip` is a more explicit way of accomplishing that.
-    #[must_use]
+    #[must_use = "data from ByteWriter will contain garbage if not used (use skip() if this is intended)"]
     pub fn split_off(&mut self, len: usize) -> Result<Self, Error> {
         if self.space_left() < len {
             Err(Error::Eof)
@@ -415,7 +415,7 @@ impl<'a> ByteReader<'a> {
     ///
     /// Note that if the created `ByteReader` is not used, the bytes will be ignored. If you are
     /// really sure you want that, `skip` is a more explicit way of accomplishing that.
-    #[must_use]
+    #[must_use = "data from ByteReader will be ignored if not used (use skip() if this is intended)"]
     pub fn split_off(&mut self, len: usize) -> Result<Self, Error> {
         if self.bytes_left() < len {
             Err(Error::Eof)

--- a/rubble/src/ecdh/p256.rs
+++ b/rubble/src/ecdh/p256.rs
@@ -1,7 +1,11 @@
 use super::*;
-use ::p256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
-use ::p256::elliptic_curve::Field;
-use ::p256::{ProjectivePoint, Scalar};
+use ::p256::{
+    elliptic_curve::{
+        sec1::{FromEncodedPoint, ToEncodedPoint},
+        Field,
+    },
+    ProjectivePoint, Scalar,
+};
 use rand_core::{CryptoRng, RngCore};
 
 /// An ECDH provider using the pure-Rust `p256` crate.
@@ -24,7 +28,7 @@ impl EcdhProvider for P256Provider {
         let scalar = Scalar::random(rng);
         let secret = P256SecretKey { inner: scalar };
 
-        let public = ProjectivePoint::generator() * &scalar;
+        let public = ProjectivePoint::generator() * scalar;
         let public = public.to_affine();
         let public = public.to_encoded_point(false);
 
@@ -67,11 +71,11 @@ impl SecretKey for P256SecretKey {
 
         // ECDH is nothing but multiplying the foreign public key by the local secret key.
         let affine = ::p256::AffinePoint::from_encoded_point(&foreign_key);
-        if affine.is_none().into() {
+        if affine.is_none() {
             return Err(InvalidPublicKey::new());
         }
 
-        let mul_point = ProjectivePoint::from(affine.unwrap()) * &self.inner;
+        let mul_point = ProjectivePoint::from(affine.unwrap()) * self.inner;
         let uncomp_point = ::p256::EncodedPoint::from(mul_point.to_affine());
 
         // First byte is a `0x04` tag, next 32 Bytes are the shared secret.

--- a/rubble/src/error.rs
+++ b/rubble/src/error.rs
@@ -2,6 +2,7 @@ use core::fmt;
 
 /// Errors returned by the BLE stack.
 #[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Error {
     /// Packet specified an invalid length value or was too short.
     ///
@@ -21,9 +22,6 @@ pub enum Error {
 
     /// Parsing didn't consume the entire buffer.
     IncompleteParse,
-
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl fmt::Display for Error {
@@ -33,7 +31,6 @@ impl fmt::Display for Error {
             Error::InvalidValue => "invalid value for field",
             Error::Eof => "end of buffer",
             Error::IncompleteParse => "excess data in buffer",
-            Error::__Nonexhaustive => unreachable!(),
         })
     }
 }

--- a/rubble/src/l2cap/mod.rs
+++ b/rubble/src/l2cap/mod.rs
@@ -88,10 +88,7 @@ impl Channel {
     ///
     /// L2CAP PDUs addressed to connectionless channels are called *G-frames*.
     pub fn is_connectionless(&self) -> bool {
-        match self.0 {
-            0x0002 | 0x0001 | 0x0005 => true,
-            _ => false,
-        }
+        matches!(self.0, 0x0002 | 0x0001 | 0x0005)
     }
 }
 

--- a/rubble/src/link/ad_structure.rs
+++ b/rubble/src/link/ad_structure.rs
@@ -21,6 +21,7 @@ use bitflags::bitflags;
 ///
 /// From a very unrepresentative scan, most devices seem to include Flags and Manufacturer Data, and
 /// optionally a device name, of course.
+#[non_exhaustive]
 #[derive(Debug, Copy, Clone)]
 pub enum AdStructure<'a> {
     /// Device flags and baseband capabilities.
@@ -64,9 +65,6 @@ pub enum AdStructure<'a> {
         /// Raw data transmitted after the type.
         data: &'a [u8],
     },
-
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl<'a> ToBytes for AdStructure<'a> {
@@ -116,7 +114,6 @@ impl<'a> ToBytes for AdStructure<'a> {
                 buf.write_u8(*ty)?;
                 buf.write_slice(data)?;
             }
-            AdStructure::__Nonexhaustive => unreachable!(),
         }
         let len = left_before - buf.space_left();
         assert!(len <= 255);

--- a/rubble/src/link/connection.rs
+++ b/rubble/src/link/connection.rs
@@ -204,11 +204,10 @@ impl<C: Config> Connection<C> {
                 // resent until we have space.
 
                 let result: Result<(), Error> =
-                    self.rx
-                        .produce_with(header.payload_length().into(), |writer| {
-                            writer.write_slice(payload)?;
-                            Ok(header.llid())
-                        });
+                    self.rx.produce_with(header.payload_length(), |writer| {
+                        writer.write_slice(payload)?;
+                        Ok(header.llid())
+                    });
 
                 if result.is_ok() {
                     // Acknowledge the packet

--- a/rubble/src/link/mod.rs
+++ b/rubble/src/link/mod.rs
@@ -445,20 +445,12 @@ impl<C: Config> LinkLayer<C> {
 
     /// Returns whether the Link-Layer is currently broadcasting advertisement packets.
     pub fn is_advertising(&self) -> bool {
-        if let State::Advertising { .. } = self.state {
-            true
-        } else {
-            false
-        }
+        matches!(self.state, State::Advertising { .. })
     }
 
     /// Returns whether the Link-Layer is currently connected.
     pub fn is_connected(&self) -> bool {
-        if let State::Connection { .. } = self.state {
-            true
-        } else {
-            false
-        }
+        matches!(self.state, State::Connection { .. })
     }
 }
 

--- a/rubble/src/link/responder.rs
+++ b/rubble/src/link/responder.rs
@@ -65,13 +65,10 @@ impl<C: Config> Responder<C> {
                     info!("-> Response: {:?}", response);
 
                     // Consume the LL Control PDU iff we can fit the response in the TX buffer:
-                    Consume::on_success(this.tx.produce_with(
-                        response.encoded_size().into(),
-                        |writer| {
-                            response.to_bytes(writer)?;
-                            Ok(Llid::Control)
-                        },
-                    ))
+                    Consume::on_success(this.tx.produce_with(response.encoded_size(), |writer| {
+                        response.to_bytes(writer)?;
+                        Ok(Llid::Control)
+                    }))
                 }
                 Pdu::DataStart { message } => {
                     info!("L2start: {:?}", HexSlice(message));

--- a/rubble/src/uuid.rs
+++ b/rubble/src/uuid.rs
@@ -188,6 +188,7 @@ impl fmt::Debug for Uuid32 {
 }
 
 impl fmt::Debug for Uuid128 {
+    #[allow(clippy::many_single_char_names, clippy::just_underscores_and_digits)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15] = self.0;
         let a = u32::from_be_bytes([_0, _1, _2, _3]);


### PR DESCRIPTION
I've been using `cargo clippy` to check idioms, and I thought it might be helpful to clean up some of the warnings. This PR takes care of most of them (things like the `#[non_exhaustive]` attribute on enums and extraneous `.into()` calls). Here's the warnings reported that I haven't fixed:

- [new_without_default](https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default): not sure if this is something you want to have with the API, and it's easy to suppress if you don't want it
- [eval_order_dependence](https://rust-lang.github.io/rust-clippy/master/index.html#eval_order_dependence
): (occurs [here](https://github.com/jonas-schievink/rubble/blob/master/rubble/src/link/advertising.rs#L430)) it seems like order of evaluation for struct fields is not well-defined, but this chunk of code is hard to refactor to accommodate without making a bunch of let bindings.
- no-op: (occurs [here](https://github.com/jonas-schievink/rubble/blob/master/rubble/src/uuid.rs#L112)) I'm not sure what this code is supposed to do, but the compiler seems to report it as a no-op - is it intended to panic?