### PR TITLE
Basic implementation for read blob, read dynamic attributes, prepare and execute write and find information

### DIFF
--- a/rubble/src/att/mod.rs
+++ b/rubble/src/att/mod.rs
@@ -35,7 +35,7 @@ mod server;
 mod uuid;
 
 use self::{handle::*, pdus::*};
-use crate::Error;
+use crate::{l2cap::Sender, Error};
 
 pub use self::handle::{Handle, HandleRange};
 pub use self::server::{AttributeServer, AttributeServerTx};
@@ -166,6 +166,39 @@ pub trait AttributeProvider {
     /// `attribute_access_permissions` is.
     fn write_attr(&mut self, _handle: Handle, _data: &[u8]) -> Result<(), Error> {
         unimplemented!("by default, no attributes should have write access permissions, and this should never be called");
+    }
+
+    /// If this read is from dynamic data fill the buffer and return the length of the data.
+    /// If not return None.
+    ///
+    /// By default returns `None`.
+    fn read_attr_dynamic(&mut self, _handle: Handle, _buffer: &mut [u8]) -> Option<usize> {
+        None
+    }
+
+    /// In order to write data longer than the MTU the procedure is explained in
+    /// BLUETOOTH CORE SPECIFICATION Version 5.2 | Vol 3, Part F section 3.4.6.
+    fn prepare_write_attr(
+        &mut self,
+        _handle: Handle,
+        _offset: u16,
+        _data: &[u8],
+    ) -> Result<(), Error> {
+        unimplemented!("you need to implement prepare_write_attr to make queued writes work")
+    }
+
+    /// In order to write data longer than the MTU the procedure is explained in
+    /// BLUETOOTH CORE SPECIFICATION Version 5.2 | Vol 3, Part F section 3.4.6.
+    fn execute_write_attr(&mut self, _flags: u8) -> Result<(), Error> {
+        unimplemented!("you need to implement execute_write_attr to make queued writes work")
+    }
+
+    fn find_information(
+        &mut self,
+        _range: HandleRange,
+        _responder: &mut Sender<'_>,
+    ) -> Result<(), Error> {
+        unimplemented!("you need to implement find_information to make things like Client Characteristic Configuration work")
     }
 }
 

--- a/rubble/src/att/mod.rs
+++ b/rubble/src/att/mod.rs
@@ -171,12 +171,14 @@ pub trait AttributeProvider {
     /// If this read is from dynamic data fill the buffer and return the length of the data.
     /// If not return None.
     ///
+    /// Currently the buffer is 256 bytes.
+    ///
     /// By default returns `None`.
     fn read_attr_dynamic(&mut self, _handle: Handle, _buffer: &mut [u8]) -> Option<usize> {
         None
     }
 
-    /// In order to write data longer than the MTU the procedure is explained in
+    /// In order to write data longer than what would fit one write request the procedure is explained in
     /// BLUETOOTH CORE SPECIFICATION Version 5.2 | Vol 3, Part F section 3.4.6.
     fn prepare_write_attr(
         &mut self,
@@ -187,12 +189,13 @@ pub trait AttributeProvider {
         unimplemented!("you need to implement prepare_write_attr to make queued writes work")
     }
 
-    /// In order to write data longer than the MTU the procedure is explained in
+    /// In order to write data longer than what would fit one write request the procedure is explained in
     /// BLUETOOTH CORE SPECIFICATION Version 5.2 | Vol 3, Part F section 3.4.6.
     fn execute_write_attr(&mut self, _flags: u8) -> Result<(), Error> {
         unimplemented!("you need to implement execute_write_attr to make queued writes work")
     }
 
+    /// See BLUETOOTH CORE SPECIFICATION Version 5.2 | Vol 3, Part F section 3.4.3.1 on what to implement here.
     fn find_information(
         &mut self,
         _range: HandleRange,

--- a/rubble/src/att/server.rs
+++ b/rubble/src/att/server.rs
@@ -234,7 +234,7 @@ impl<A: AttributeProvider> AttributeServer<A> {
                     .send_with(|writer| -> Result<(), Error> {
                         writer.write_u8(Opcode::ReadBlobRsp.into())?;
 
-                        let mut buffer = [0u8; 256];
+                        let mut buffer = [0u8; 256]; // this limits the maximum value size to 256 bytes
                         if let Some(data_len) = self.attrs.read_attr_dynamic(*handle, &mut buffer) {
                             let offset = *offset as usize;
                             let slice = &buffer[..data_len];

--- a/rubble/src/att/server.rs
+++ b/rubble/src/att/server.rs
@@ -200,24 +200,70 @@ impl<A: AttributeProvider> AttributeServer<A> {
                     .send_with(|writer| -> Result<(), Error> {
                         writer.write_u8(Opcode::ReadRsp.into())?;
 
-                        self.attrs.for_attrs_in_range(
-                            HandleRange::new(*handle, *handle),
-                            |_provider, attr| {
-                                // FIXME return if attribute is not readable
-                                // This code currently doesn't work because the callback should
-                                // return rubble::Error rather than an AtError
-                                // if !self.attrs.attr_access_permissions(*handle).is_readable() {
-                                //     return
-                                //     Err(AttError::new(ErrorCode::ReadNotPermitted, *handle))
-                                // }
-                                let value = if writer.space_left() < attr.value.as_ref().len() {
-                                    &attr.value.as_ref()[..writer.space_left()]
-                                } else {
-                                    attr.value.as_ref()
-                                };
-                                writer.write_slice(value)
-                            },
-                        )?;
+                        let mut buffer = [0u8; 256]; // this limits the maximum value size to 256 bytes
+                        if let Some(data_len) = self.attrs.read_attr_dynamic(*handle, &mut buffer) {
+                            let value = &buffer[..data_len];
+                            writer.write_slice_truncate(value);
+                        } else {
+                            self.attrs.for_attrs_in_range(
+                                HandleRange::new(*handle, *handle),
+                                |_provider, attr| {
+                                    // FIXME return if attribute is not readable
+                                    // This code currently doesn't work because the callback should
+                                    // return rubble::Error rather than an AtError
+                                    // if !self.attrs.attr_access_permissions(*handle).is_readable() {
+                                    //     return
+                                    //     Err(AttError::new(ErrorCode::ReadNotPermitted, *handle))
+                                    // }
+                                    let value = &attr.value.as_ref();
+                                    writer.write_slice_truncate(value);
+                                    Ok(())
+                                },
+                            )?;
+                        }
+
+                        Ok(())
+                    })
+                    .unwrap();
+
+                Ok(())
+            }
+
+            AttPdu::ReadBlobReq { handle, offset } => {
+                responder
+                    .send_with(|writer| -> Result<(), Error> {
+                        writer.write_u8(Opcode::ReadBlobRsp.into())?;
+
+                        let mut buffer = [0u8; 256];
+                        if let Some(data_len) = self.attrs.read_attr_dynamic(*handle, &mut buffer) {
+                            let offset = *offset as usize;
+                            let slice = &buffer[..data_len];
+                            let slice = &slice[offset..];
+
+                            let value = slice.as_ref();
+
+                            writer.write_slice_truncate(value);
+                        } else {
+                            self.attrs.for_attrs_in_range(
+                                HandleRange::new(*handle, *handle),
+                                |_provider, attr| {
+                                    // FIXME return if attribute is not readable
+                                    // This code currently doesn't work because the callback should
+                                    // return rubble::Error rather than an AtError
+                                    // if !self.attrs.attr_access_permissions(*handle).is_readable() {
+                                    //     return
+                                    //     Err(AttError::new(ErrorCode::ReadNotPermitted, *handle))
+                                    // }
+                                    let value = attr.value.as_ref();
+                                    let offset = *offset as usize;
+                                    let slice = &value[offset..];
+
+                                    writer.write_slice_truncate(slice);
+
+                                    Ok(())
+                                },
+                            )?;
+                        }
 
                         Ok(())
                     })
@@ -263,6 +309,77 @@ impl<A: AttributeProvider> AttributeServer<A> {
                 Ok(())
             }
 
+            AttPdu::PrepareWriteReq {
+                handle,
+                offset,
+                value,
+            } => {
+                if self.attrs.attr_access_permissions(*handle).is_writeable() {
+                    self.attrs
+                        .prepare_write_attr(*handle, *offset, value.as_ref())
+                        .map_err(|err| {
+                            // Convert rubble::Error to AttError
+                            AttError::new(
+                                match err {
+                                    Error::InvalidLength => ErrorCode::InvalidAttributeValueLength,
+                                    _ => ErrorCode::UnlikelyError,
+                                },
+                                *handle,
+                            )
+                        })?;
+                    responder
+                        .send_with(|writer| -> Result<(), Error> {
+                            writer.write_u8(Opcode::PrepareWriteRsp.into())?;
+                            writer.write_u16_le(handle.as_u16())?;
+                            writer.write_u16_le(*offset)?;
+                            writer.write_slice(value.as_ref())?;
+                            Ok(())
+                        })
+                        .map_err(|err| error!("error while handling write request: {:?}", err))
+                        .ok();
+                    Ok(())
+                } else {
+                    Err(AttError::new(ErrorCode::WriteNotPermitted, *handle))
+                }
+            }
+
+            AttPdu::ExecuteWriteReq { flags } => {
+                self.attrs.execute_write_attr(*flags).map_err(|err| {
+                    // Convert rubble::Error to AttError
+                    AttError::new(
+                        match err {
+                            Error::InvalidLength => ErrorCode::InvalidAttributeValueLength,
+                            _ => ErrorCode::UnlikelyError,
+                        },
+                        Handle::NULL,
+                    )
+                })?;
+                responder
+                    .send_with(|writer| -> Result<(), Error> {
+                        writer.write_u8(Opcode::ExecuteWriteRsp.into())?;
+                        Ok(())
+                    })
+                    .map_err(|err| error!("error while handling write request: {:?}", err))
+                    .ok();
+                Ok(())
+            }
+
+            AttPdu::FindInformationReq { handle_range } => {
+                let range = handle_range.check()?;
+                self.attrs
+                    .find_information(range, responder)
+                    .map_err(|err| {
+                        // Convert rubble::Error to AttError
+                        AttError::new(
+                            match err {
+                                Error::InvalidLength => ErrorCode::InvalidAttributeValueLength,
+                                _ => ErrorCode::UnlikelyError,
+                            },
+                            Handle::NULL,
+                        )
+                    })
+            }
+
             // Responses are always invalid here
             AttPdu::ErrorRsp { .. }
             | AttPdu::ExchangeMtuRsp { .. }
@@ -283,12 +400,8 @@ impl<A: AttributeProvider> AttributeServer<A> {
 
             // Unknown (undecoded) or unimplemented requests and commands
             AttPdu::Unknown { .. }
-            | AttPdu::FindInformationReq { .. }
             | AttPdu::FindByTypeValueReq { .. }
-            | AttPdu::ReadBlobReq { .. }
             | AttPdu::ReadMultipleReq { .. }
-            | AttPdu::PrepareWriteReq { .. }
-            | AttPdu::ExecuteWriteReq { .. }
             | AttPdu::SignedWriteCommand { .. }
             | AttPdu::HandleValueConfirmation { .. } => {
                 if msg.opcode().is_command() {


### PR DESCRIPTION
This PR adds basic support for
- read blob
- reading dynamic attributes (i.e. dynamic length and content)
- prepare and execute write
- bare bones support for find information

I tested the the implementation on a NRF52832DK board, and it seems to work as expected. I didn't added this to the demo code contained in this repository since I guess it might cause too much confusion for someone just wanting to learn Rubble.

But I have some demo code at https://github.com/bjoernQ/rubble-no-rtic-demo/tree/demo_additional_requests

I am not really happy about the fixed size of the buffer for dynamic read attributes but I have no better idea for now.

I am not too sure if the way that `find information` is implemented is  a bit too low level - but at least it gives the user ultimate choice about the implementation.
