### PR TITLE
Upgrade defmt to 0.3.0

### DIFF
--- a/rubble/Cargo.toml
+++ b/rubble/Cargo.toml
@@ -16,7 +16,7 @@ heapless = "0.7.1"
 rand_core = "0.6.3"
 sha2 = { version = "0.9.0", default-features = false }
 zerocopy = "0.5.0"
-defmt = "0.2.3"
+defmt = "0.3.0"
 
 [dependencies.p256]
 version = "0.9.0"

--- a/rubble/src/time.rs
+++ b/rubble/src/time.rs
@@ -130,7 +130,7 @@ impl fmt::Debug for Duration {
 
 impl defmt::Format for Duration {
     fn format(&self, fmt: defmt::Formatter<'_>) {
-        defmt::write!(fmt, "{=u32:µs}s", self.0);
+        defmt::write!(fmt, "{=u32:us}s", self.0);
     }
 }
 


### PR DESCRIPTION
Because defmt has a native dependency you can't have multiple version of it in your dependency tree. In order to use the latest version of `cortex-m-rt` I had to upgrade defmt.