### PR TITLE
Update bbqueue in demo

### DIFF
--- a/demos/demo-utils/Cargo.toml
+++ b/demos/demo-utils/Cargo.toml
@@ -14,4 +14,4 @@ publish = false
 rubble = { path = "../../rubble", default-features = false }
 cortex-m = "0.7.2"
 log = "0.4.8"
-bbqueue = "0.4.1"
+bbqueue = "0.5.1"

--- a/demos/demo-utils/src/logging.rs
+++ b/demos/demo-utils/src/logging.rs
@@ -1,6 +1,6 @@
 //! Logging-related utilities and adapters.
 
-use bbqueue::{ArrayLength, GrantW, Producer};
+use bbqueue::{GrantW, Producer};
 use core::{cell::RefCell, fmt};
 use cortex_m::interrupt::{self, Mutex};
 use log::{Log, Metadata, Record};
@@ -40,12 +40,12 @@ impl<T: Timer, L: fmt::Write> fmt::Write for StampedLogger<T, L> {
 ///
 /// The sink will panic when the `BBBuffer` doesn't have enough space to the data. This is to ensure
 /// that we never block or drop data.
-pub struct BbqLogger<'a, N: ArrayLength<u8>> {
+pub struct BbqLogger<'a, const N: usize> {
     p: Producer<'a, N>,
     data_lost: bool,
 }
 
-impl<'a, N: ArrayLength<u8>> BbqLogger<'a, N> {
+impl<'a, const N: usize> BbqLogger<'a, N> {
     pub fn new(p: Producer<'a, N>) -> Self {
         Self {
             p,
@@ -54,7 +54,7 @@ impl<'a, N: ArrayLength<u8>> BbqLogger<'a, N> {
     }
 }
 
-impl<N: ArrayLength<u8>> fmt::Write for BbqLogger<'_, N> {
+impl<const N: usize> fmt::Write for BbqLogger<'_, N> {
     fn write_str(&mut self, msg: &str) -> fmt::Result {
         let mut msg_bytes = msg.as_bytes();
         while !msg_bytes.is_empty() {
@@ -88,12 +88,12 @@ impl<N: ArrayLength<u8>> fmt::Write for BbqLogger<'_, N> {
 }
 
 /// Wraps a granted buffer and provides convenience methods to append data and commit
-struct GrantedBuffer<'a, N: ArrayLength<u8>> {
+struct GrantedBuffer<'a, const N: usize> {
     grant: GrantW<'a, N>,
     written: usize,
 }
 
-impl<'a, N: ArrayLength<u8>> GrantedBuffer<'a, N> {
+impl<'a, const N: usize> GrantedBuffer<'a, N> {
     pub fn new(grant: GrantW<'a, N>) -> Self {
         GrantedBuffer { grant, written: 0 }
     }

--- a/demos/nrf52-demo/Cargo.toml
+++ b/demos/nrf52-demo/Cargo.toml
@@ -17,7 +17,7 @@ demo-utils = { path = "../demo-utils" }
 cortex-m = "0.7.2"
 cortex-m-rtic = { version = "0.5.8", default-features = false, features = ["cortex-m-7"] }
 cortex-m-rt = "0.7.0"
-bbqueue = "0.4"
+bbqueue = "0.5.1"
 rtt-target = { version = "0.3.0", features = ["cortex-m"] }
 panic-rtt-target = { version = "0.1.1", features = ["cortex-m"] }
 

--- a/demos/nrf52-demo/src/main.rs
+++ b/demos/nrf52-demo/src/main.rs
@@ -65,7 +65,7 @@ const APP: () = {
         ble_r: Responder<AppConfig>,
         radio: BleRadio,
         log_channel: UpChannel,
-        log_sink: Consumer<'static, logger::BufferSize>,
+        log_sink: Consumer<'static, { logger::BUFFER_SIZE }>,
     }
 
     #[init(resources = [ble_tx_buf, ble_rx_buf, tx_queue, rx_queue])]


### PR DESCRIPTION
Since Rust now supports const generics we can use bbqueue 0.5.1 which supports them instead of using `typenum`